### PR TITLE
Add Camera Module 3 capture CLI

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,6 +5,16 @@
 rpicam-still -o photo1.jpg --quality 95 --sharpness 0.5 --contrast 0.9 --saturation 0.9
 ```
 
+## Take a photo with the Python capture code
+```bash
+python3 src/tiny-film-cam/capture.py --output photo1.jpg
+```
+
+## Take a full-size Camera Module 3 photo
+```bash
+python3 src/tiny-film-cam/capture.py --output photo1.jpg --width 4608 --height 2592
+```
+
 ## Transfer photos to local machine
 ```bash
 scp suveen@172.20.10.2:/home/suveen/photo.jpg .

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -1,0 +1,26 @@
+# tiny-film-cam
+
+Capture-only Raspberry Pi camera code for Tiny Film.
+
+This folder intentionally contains only the local camera capture path. It does
+not include OpenAI image generation, queues, phone UI, or service deployment.
+
+Run one capture from the project root on the Raspberry Pi:
+
+```bash
+python3 src/tiny-film-cam/capture.py --output photo1.jpg
+```
+
+If `--output` is omitted, the script writes a timestamped JPEG into `images/`.
+
+For a Camera Module 3 full-size still, pass an explicit size:
+
+```bash
+python3 src/tiny-film-cam/capture.py --output photo1.jpg --width 4608 --height 2592
+```
+
+The default image tuning matches the existing `rpicam-still` command:
+
+```text
+quality=95, sharpness=0.5, contrast=0.9, saturation=0.9
+```

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+
+Rotation = Literal[0, 90, 180, 270]
+FocusMode = Literal["default", "auto", "continuous", "manual"]
+
+
+@dataclass(frozen=True)
+class CaptureSettings:
+    output_dir: Path = Path("images")
+    filename: str | None = None
+    width: int | None = None
+    height: int | None = None
+    quality: int = 95
+    sharpness: float = 0.5
+    contrast: float = 0.9
+    saturation: float = 0.9
+    rotation: Rotation = 0
+    warmup_seconds: float = 0.5
+    focus_mode: FocusMode = "continuous"
+    lens_position: float | None = None
+
+
+def _timestamped_filename() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S-%f.jpg")
+
+
+def _normalized_quality(value: int) -> int:
+    return max(1, min(100, int(value)))
+
+
+def _output_path(settings: CaptureSettings) -> Path:
+    if settings.filename:
+        path = Path(settings.filename).expanduser()
+    else:
+        path = settings.output_dir.expanduser() / _timestamped_filename()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _rotate_image(image, rotation: Rotation):
+    from PIL import Image
+
+    if rotation == 90:
+        return image.transpose(Image.Transpose.ROTATE_90)
+    if rotation == 180:
+        return image.transpose(Image.Transpose.ROTATE_180)
+    if rotation == 270:
+        return image.transpose(Image.Transpose.ROTATE_270)
+    return image
+
+
+def _camera_controls(settings: CaptureSettings) -> dict[str, object]:
+    controls: dict[str, object] = {
+        "Sharpness": settings.sharpness,
+        "Contrast": settings.contrast,
+        "Saturation": settings.saturation,
+    }
+
+    try:
+        from libcamera import controls as libcamera_controls
+    except ImportError:
+        return controls
+
+    if settings.focus_mode == "auto":
+        controls["AfMode"] = libcamera_controls.AfModeEnum.Auto
+    elif settings.focus_mode == "continuous":
+        controls["AfMode"] = libcamera_controls.AfModeEnum.Continuous
+    elif settings.focus_mode == "manual":
+        controls["AfMode"] = libcamera_controls.AfModeEnum.Manual
+        if settings.lens_position is not None:
+            controls["LensPosition"] = settings.lens_position
+
+    return controls
+
+
+def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
+    """Capture one still image from a Raspberry Pi Camera Module 3."""
+    import time
+
+    from PIL import Image
+    from picamera2 import Picamera2
+
+    picam2 = Picamera2()
+    main_config: dict[str, object] = {"format": "RGB888"}
+    if settings.width and settings.height:
+        main_config["size"] = (settings.width, settings.height)
+
+    config = picam2.create_still_configuration(
+        main=main_config,
+        controls=_camera_controls(settings),
+    )
+    output_path = _output_path(settings)
+    started = False
+
+    try:
+        picam2.configure(config)
+        picam2.start()
+        started = True
+        if settings.warmup_seconds > 0:
+            time.sleep(settings.warmup_seconds)
+
+        frame = picam2.capture_array("main")
+    finally:
+        if started:
+            picam2.stop()
+        picam2.close()
+
+    image = Image.fromarray(frame, "RGB")
+    image = _rotate_image(image, settings.rotation)
+    image.save(output_path, format="JPEG", quality=_normalized_quality(settings.quality))
+    return output_path

--- a/src/tiny-film-cam/capture.py
+++ b/src/tiny-film-cam/capture.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from camera import CaptureSettings, capture_photo
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Capture a still photo with a Raspberry Pi Camera Module 3."
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output filename, like rpicam-still -o.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="images",
+        help="Directory for timestamped output when --output is omitted.",
+    )
+    parser.add_argument("--width", type=int, help="Optional still capture width.")
+    parser.add_argument("--height", type=int, help="Optional still capture height.")
+    parser.add_argument("--quality", type=int, default=95, help="JPEG quality, 1-100.")
+    parser.add_argument("--sharpness", type=float, default=0.5)
+    parser.add_argument("--contrast", type=float, default=0.9)
+    parser.add_argument("--saturation", type=float, default=0.9)
+    parser.add_argument(
+        "--rotation",
+        type=int,
+        choices=(0, 90, 180, 270),
+        default=0,
+        help="Rotate the saved JPEG after capture.",
+    )
+    parser.add_argument(
+        "--warmup-seconds",
+        type=float,
+        default=0.5,
+        help="Seconds to let exposure/focus settle before capture.",
+    )
+    parser.add_argument(
+        "--focus-mode",
+        choices=("default", "auto", "continuous", "manual"),
+        default="continuous",
+        help="Camera Module 3 focus mode.",
+    )
+    parser.add_argument(
+        "--lens-position",
+        type=float,
+        help="Manual lens position. Only used with --focus-mode manual.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    settings = CaptureSettings(
+        output_dir=Path(args.output_dir),
+        filename=args.output,
+        width=args.width,
+        height=args.height,
+        quality=args.quality,
+        sharpness=args.sharpness,
+        contrast=args.contrast,
+        saturation=args.saturation,
+        rotation=args.rotation,
+        warmup_seconds=args.warmup_seconds,
+        focus_mode=args.focus_mode,
+        lens_position=args.lens_position,
+    )
+    output_path = capture_photo(settings)
+    print(f"Saved photo to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a capture-only Picamera2 module for Raspberry Pi Camera Module 3
- add a CLI for taking JPEG stills with quality, tuning, rotation, warmup, and focus options
- document the new Python capture commands alongside the existing rpicam-still command

## Testing
- python3 -m py_compile src/tiny-film-cam/camera.py src/tiny-film-cam/capture.py
- python3 src/tiny-film-cam/capture.py --help

Note: actual camera capture needs to be run on the Raspberry Pi with Camera Module 3 hardware.