### PR TITLE
[codex] Add mobile web capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ python3 src/tiny-film-cam/web.py
 ```
 
 Then open `http://<pi-ip>:8000` from a phone on the same Wi-Fi network.
+Tap **Take Photo** to capture from the phone.
 
 ## Boot services
 
@@ -20,10 +21,10 @@ Install the web app and physical shutter services on the Raspberry Pi:
 ./scripts/install_service.sh --enable-now
 ```
 
-The web service starts the phone app on port `8000`. The shutter service listens
-for a simple physical button on BCM GPIO 17 by default and saves each capture to
-`data/captures/`. Wire the button between BCM GPIO 17, physical pin 11, and any
-GND pin.
+The web service starts the phone app on port `8000`. The phone app and shutter
+service both save captures to `data/captures/`. The shutter service listens for
+a simple physical button on BCM GPIO 17 by default. Wire the button between BCM
+GPIO 17, physical pin 11, and any GND pin.
 
 To change the button pin or capture settings, copy `.env.example` to `.env` and
 edit the `TINY_FILM_*` values.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,11 @@ sudo systemctl restart tiny-film-web.service tiny-film-shutter.service
 sudo systemctl status tiny-film-web.service tiny-film-shutter.service --no-pager
 ```
 
+## Take a photo through the web server
+```bash
+curl -X POST http://localhost:8000/api/capture
+```
+
 ## Follow service logs
 ```bash
 sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -f

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -42,6 +42,7 @@ The web app serves captures from `data/captures/` and exposes:
 
 - `GET /`
 - `GET /api/images`
+- `POST /api/capture`
 - `GET /download/captures/`
 - `GET /api/device-details`
 - `GET /latest-image`

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+import fcntl
+import os
 from pathlib import Path
-from typing import Literal
+from typing import Iterator, Literal
 
 
 Rotation = Literal[0, 90, 180, 270]
 FocusMode = Literal["default", "auto", "continuous", "manual"]
+ROTATIONS = {0, 90, 180, 270}
+FOCUS_MODES = {"default", "auto", "continuous", "manual"}
 
 
 @dataclass(frozen=True)
@@ -24,6 +29,80 @@ class CaptureSettings:
     warmup_seconds: float = 0.5
     focus_mode: FocusMode = "continuous"
     lens_position: float | None = None
+
+
+def env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    return float(value)
+
+
+def env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    return int(value)
+
+
+def env_optional_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
+    return int(value)
+
+
+def env_optional_float(name: str) -> float | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
+    return float(value)
+
+
+def resolve_project_path(project_root: Path, value: str | Path) -> Path:
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    return project_root / path
+
+
+def capture_output_dir_from_env(project_root: Path) -> Path:
+    output_dir = os.environ.get("TINY_FILM_OUTPUT_DIR", "data/captures")
+    return resolve_project_path(project_root, output_dir)
+
+
+def capture_settings_from_env(project_root: Path) -> CaptureSettings:
+    focus_mode = os.environ.get("TINY_FILM_CAPTURE_FOCUS_MODE", "continuous")
+    if focus_mode not in FOCUS_MODES:
+        focus_mode = "continuous"
+    rotation = env_int("TINY_FILM_CAPTURE_ROTATION", 0)
+    if rotation not in ROTATIONS:
+        rotation = 0
+    return CaptureSettings(
+        output_dir=capture_output_dir_from_env(project_root),
+        width=env_optional_int("TINY_FILM_CAPTURE_WIDTH"),
+        height=env_optional_int("TINY_FILM_CAPTURE_HEIGHT"),
+        quality=env_int("TINY_FILM_CAPTURE_QUALITY", 95),
+        sharpness=env_float("TINY_FILM_CAPTURE_SHARPNESS", 0.5),
+        contrast=env_float("TINY_FILM_CAPTURE_CONTRAST", 0.9),
+        saturation=env_float("TINY_FILM_CAPTURE_SATURATION", 0.9),
+        rotation=rotation,  # type: ignore[arg-type]
+        warmup_seconds=env_float("TINY_FILM_CAPTURE_WARMUP_SECONDS", 0.5),
+        focus_mode=focus_mode,  # type: ignore[arg-type]
+        lens_position=env_optional_float("TINY_FILM_CAPTURE_LENS_POSITION"),
+    )
+
+
+@contextmanager
+def _locked_camera(output_dir: Path) -> Iterator[None]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = output_dir / ".tiny-film-camera.lock"
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def _timestamped_path(output_dir: Path) -> Path:
@@ -89,32 +168,33 @@ def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
     from PIL import Image
     from picamera2 import Picamera2
 
-    picam2 = Picamera2()
-    main_config: dict[str, object] = {"format": "RGB888"}
-    if settings.width and settings.height:
-        main_config["size"] = (settings.width, settings.height)
+    with _locked_camera(settings.output_dir.expanduser()):
+        picam2 = Picamera2()
+        main_config: dict[str, object] = {"format": "RGB888"}
+        if settings.width and settings.height:
+            main_config["size"] = (settings.width, settings.height)
 
-    config = picam2.create_still_configuration(
-        main=main_config,
-        controls=_camera_controls(settings),
-    )
-    output_path = _output_path(settings)
-    started = False
+        config = picam2.create_still_configuration(
+            main=main_config,
+            controls=_camera_controls(settings),
+        )
+        output_path = _output_path(settings)
+        started = False
 
-    try:
-        picam2.configure(config)
-        picam2.start()
-        started = True
-        if settings.warmup_seconds > 0:
-            time.sleep(settings.warmup_seconds)
+        try:
+            picam2.configure(config)
+            picam2.start()
+            started = True
+            if settings.warmup_seconds > 0:
+                time.sleep(settings.warmup_seconds)
 
-        frame = picam2.capture_array("main")
-    finally:
-        if started:
-            picam2.stop()
-        picam2.close()
+            frame = picam2.capture_array("main")
+        finally:
+            if started:
+                picam2.stop()
+            picam2.close()
 
-    image = Image.fromarray(frame, "RGB")
-    image = _rotate_image(image, settings.rotation)
-    image.save(output_path, format="JPEG", quality=_normalized_quality(settings.quality))
-    return output_path
+        image = Image.fromarray(frame, "RGB")
+        image = _rotate_image(image, settings.rotation)
+        image.save(output_path, format="JPEG", quality=_normalized_quality(settings.quality))
+        return output_path

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -7,7 +7,12 @@ import signal
 import threading
 from pathlib import Path
 
-from camera import CaptureSettings, capture_photo
+from camera import (
+    CaptureSettings,
+    capture_photo,
+    capture_settings_from_env,
+    resolve_project_path,
+)
 
 
 LOGGER = logging.getLogger("tiny_film.shutter")
@@ -20,13 +25,6 @@ def env_bool(name: str, default: bool) -> bool:
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
-def env_float(name: str, default: float) -> float:
-    value = os.environ.get(name)
-    if value is None or value.strip() == "":
-        return default
-    return float(value)
-
-
 def env_int(name: str, default: int) -> int:
     value = os.environ.get(name)
     if value is None or value.strip() == "":
@@ -34,17 +32,10 @@ def env_int(name: str, default: int) -> int:
     return int(value)
 
 
-def env_optional_int(name: str) -> int | None:
+def env_float(name: str, default: float) -> float:
     value = os.environ.get(name)
     if value is None or value.strip() == "":
-        return None
-    return int(value)
-
-
-def env_optional_float(name: str) -> float | None:
-    value = os.environ.get(name)
-    if value is None or value.strip() == "":
-        return None
+        return default
     return float(value)
 
 
@@ -52,18 +43,13 @@ def default_project_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def resolve_project_path(project_root: Path, value: str) -> Path:
-    path = Path(value).expanduser()
-    if path.is_absolute():
-        return path
-    return project_root / path
-
-
 def parse_args() -> argparse.Namespace:
+    project_root = default_project_root().expanduser().resolve()
+    capture_defaults = capture_settings_from_env(project_root)
     parser = argparse.ArgumentParser(
         description="Run the Tiny Film physical shutter button listener."
     )
-    parser.add_argument("--project-root", type=Path, default=default_project_root())
+    parser.add_argument("--project-root", type=Path, default=project_root)
     parser.add_argument("--pin", type=int, default=env_int("TINY_FILM_BUTTON_PIN", 17))
     parser.set_defaults(pull_up=env_bool("TINY_FILM_BUTTON_PULL_UP", True))
     parser.add_argument("--pull-up", dest="pull_up", action="store_true")
@@ -75,50 +61,50 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output-dir",
-        default=os.environ.get("TINY_FILM_OUTPUT_DIR", "data/captures"),
+        default=str(capture_defaults.output_dir),
     )
-    parser.add_argument("--width", type=int, default=env_optional_int("TINY_FILM_CAPTURE_WIDTH"))
-    parser.add_argument("--height", type=int, default=env_optional_int("TINY_FILM_CAPTURE_HEIGHT"))
+    parser.add_argument("--width", type=int, default=capture_defaults.width)
+    parser.add_argument("--height", type=int, default=capture_defaults.height)
     parser.add_argument(
         "--quality",
         type=int,
-        default=env_int("TINY_FILM_CAPTURE_QUALITY", 95),
+        default=capture_defaults.quality,
     )
     parser.add_argument(
         "--sharpness",
         type=float,
-        default=env_float("TINY_FILM_CAPTURE_SHARPNESS", 0.5),
+        default=capture_defaults.sharpness,
     )
     parser.add_argument(
         "--contrast",
         type=float,
-        default=env_float("TINY_FILM_CAPTURE_CONTRAST", 0.9),
+        default=capture_defaults.contrast,
     )
     parser.add_argument(
         "--saturation",
         type=float,
-        default=env_float("TINY_FILM_CAPTURE_SATURATION", 0.9),
+        default=capture_defaults.saturation,
     )
     parser.add_argument(
         "--rotation",
         type=int,
         choices=(0, 90, 180, 270),
-        default=env_int("TINY_FILM_CAPTURE_ROTATION", 0),
+        default=capture_defaults.rotation,
     )
     parser.add_argument(
         "--warmup-seconds",
         type=float,
-        default=env_float("TINY_FILM_CAPTURE_WARMUP_SECONDS", 0.5),
+        default=capture_defaults.warmup_seconds,
     )
     parser.add_argument(
         "--focus-mode",
         choices=("default", "auto", "continuous", "manual"),
-        default=os.environ.get("TINY_FILM_CAPTURE_FOCUS_MODE", "continuous"),
+        default=capture_defaults.focus_mode,
     )
     parser.add_argument(
         "--lens-position",
         type=float,
-        default=env_optional_float("TINY_FILM_CAPTURE_LENS_POSITION"),
+        default=capture_defaults.lens_position,
     )
     return parser.parse_args()
 

--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -13,6 +13,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import quote, unquote
 
+from camera import capture_output_dir_from_env, capture_photo, capture_settings_from_env
+
 
 CAPTURE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
 
@@ -22,7 +24,7 @@ def default_project_root() -> Path:
 
 
 def captures_root(project_root: Path) -> Path:
-    return project_root / "data" / "captures"
+    return capture_output_dir_from_env(project_root)
 
 
 def is_capture_image_file(path: Path) -> bool:
@@ -80,6 +82,30 @@ def build_capture_image_list(project_root: Path) -> list[dict[str, object]]:
             }
         )
     return images
+
+
+def build_capture_image(project_root: Path, image_path: Path) -> dict[str, object]:
+    root = captures_root(project_root)
+    relative_path = image_path.relative_to(root).as_posix()
+    stat = image_path.stat()
+    return {
+        "filename": image_path.name,
+        "relative_path": relative_path,
+        "download_url": f"/download/captures/{quote(relative_path)}",
+        "modified_unix": stat.st_mtime,
+        "size_bytes": stat.st_size,
+    }
+
+
+def capture_from_web(project_root: Path) -> dict[str, object]:
+    output_path = capture_photo(capture_settings_from_env(project_root))
+    try:
+        output_path.relative_to(captures_root(project_root))
+    except ValueError as exc:
+        raise RuntimeError(
+            "Capture was saved outside the configured captures directory"
+        ) from exc
+    return build_capture_image(project_root, output_path)
 
 
 def build_captures_zip(project_root: Path) -> bytes:
@@ -221,7 +247,10 @@ def render_page() -> bytes:
             font-size: 13px;
             margin-top: 4px;
           }
-          a.button {
+          a.button,
+          button.button {
+            appearance: none;
+            background: transparent;
             border: 1px solid var(--fg);
             border-radius: 999px;
             color: var(--fg);
@@ -232,9 +261,24 @@ def render_page() -> bytes:
             text-decoration: none;
             white-space: nowrap;
           }
-          a.button.primary {
+          button.button {
+            cursor: pointer;
+            font-family: inherit;
+          }
+          a.button.primary,
+          button.button.primary {
             background: var(--fg);
             color: var(--bg);
+          }
+          button.button:disabled {
+            cursor: wait;
+            opacity: 0.55;
+          }
+          .actions {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
           }
           .details {
             display: grid;
@@ -265,7 +309,10 @@ def render_page() -> bytes:
         <main>
           <header>
             <h1>Tiny Film</h1>
-            <a class="button primary" href="/download/captures/">Download All</a>
+            <div class="actions">
+              <button class="button primary" id="capture-button" type="button">Take Photo</button>
+              <a class="button" href="/download/captures/">Download All</a>
+            </div>
           </header>
 
           <section class="latest">
@@ -290,6 +337,7 @@ def render_page() -> bytes:
           const latestFrame = document.getElementById("latest-frame");
           const captureList = document.getElementById("capture-list");
           const deviceDetails = document.getElementById("device-details");
+          const captureButton = document.getElementById("capture-button");
 
           function formatBytes(value) {
             if (!Number.isFinite(value)) return "";
@@ -383,6 +431,35 @@ def render_page() -> bytes:
             renderDetails(await response.json());
           }
 
+          async function takePhoto() {
+            if (captureButton.disabled) return;
+            captureButton.disabled = true;
+            captureButton.textContent = "Taking...";
+            statusElement.textContent = "Taking photo...";
+            try {
+              const response = await fetch("/api/capture", {
+                method: "POST",
+                cache: "no-store",
+              });
+              const data = await response.json().catch(() => ({}));
+              if (!response.ok) {
+                throw new Error(data.error || "Capture failed");
+              }
+              await refreshImages();
+              await refreshDetails();
+              const savedPath = data.image && data.image.relative_path ? data.image.relative_path : "photo";
+              statusElement.textContent = `Saved ${savedPath}`;
+            } catch (error) {
+              statusElement.textContent = error instanceof Error ? error.message : "Capture failed";
+            } finally {
+              captureButton.disabled = false;
+              captureButton.textContent = "Take Photo";
+            }
+          }
+
+          captureButton.addEventListener("click", () => {
+            takePhoto();
+          });
           refreshImages().catch(() => {
             statusElement.textContent = "Could not load captures.";
           });
@@ -419,10 +496,15 @@ def build_handler(project_root: Path, port: int):
             self.end_headers()
             self.wfile.write(body)
 
-        def _send_json(self, payload: dict[str, object]) -> None:
+        def _send_json(
+            self,
+            payload: dict[str, object],
+            status: HTTPStatus = HTTPStatus.OK,
+        ) -> None:
             self._send_bytes(
                 json.dumps(payload).encode("utf-8"),
                 "application/json; charset=utf-8",
+                status=status,
             )
 
         def _serve_capture(self, image_path: Path) -> None:
@@ -504,6 +586,21 @@ def build_handler(project_root: Path, port: int):
             request_path = self.path.split("?", 1)[0]
             if request_path == "/latest-image":
                 self._serve_latest_image(include_body=False)
+                return
+            self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+
+        def do_POST(self) -> None:
+            request_path = self.path.split("?", 1)[0]
+            if request_path == "/api/capture":
+                try:
+                    image = capture_from_web(project_root)
+                except Exception as exc:
+                    self._send_json(
+                        {"ok": False, "error": f"Capture failed: {exc}"},
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                    return
+                self._send_json({"ok": True, "image": image})
                 return
             self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
 


### PR DESCRIPTION
## Summary

- Add a Take Photo button to the Tiny Film phone web app.
- Add `POST /api/capture` so the phone can trigger the existing capture pipeline.
- Share capture settings between the web server and physical shutter daemon.
- Add a file lock around camera access so phone and hardware captures do not collide.
- Document the new web capture endpoint and phone workflow.

## Validation

- `python3 -m py_compile src/tiny-film-cam/camera.py src/tiny-film-cam/capture.py src/tiny-film-cam/web.py src/tiny-film-cam/shutter_daemon.py`
- `bash -n scripts/install_service.sh scripts/run_web.sh scripts/run_shutter.sh`
- Local HTTP smoke test on `127.0.0.1:8765`: verified the page includes `Take Photo`, `/api/images` returns JSON, and `POST /api/capture` returns a clean JSON error on Mac because `picamera2` is not installed.

## Notes

Actual image capture still needs verification on the Raspberry Pi camera hardware.
