### PR TITLE
Match detail font sizes

### DIFF
--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -446,11 +446,7 @@ def render_page() -> bytes:
           .metric:last-child {
             border-right: 0;
           }
-          .metric .label {
-            font-size: 12px;
-          }
           .metric .value {
-            font-size: 13px;
             margin-top: 4px;
           }
           .detail {
@@ -462,9 +458,10 @@ def render_page() -> bytes:
           }
           .label {
             color: var(--muted);
-            font-size: 14px;
+            font-size: 12px;
           }
           .value {
+            font-size: 13px;
             overflow-wrap: anywhere;
           }
           .value.warning {


### PR DESCRIPTION
## Summary
- make detail row labels use the same 12px size as battery metric labels
- make detail row values use the same 13px size as battery metric values
- remove now-redundant metric-specific font-size overrides

## Validation
- python3 -m py_compile src/tiny-film-cam/web.py
- python3 -m unittest discover -s tests
- browser check confirmed Updated, App URL, Storage, and battery metrics share matching label/value font sizes