### PR TITLE
[codex] Add film-friendly capture defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,19 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95
-TINY_FILM_CAPTURE_SHARPNESS=0.5
-TINY_FILM_CAPTURE_CONTRAST=0.9
+TINY_FILM_CAPTURE_SHARPNESS=0.3
+TINY_FILM_CAPTURE_CONTRAST=0.85
 TINY_FILM_CAPTURE_SATURATION=0.9
+TINY_FILM_CAPTURE_EV=-0.7
+# Optional comma-separated EV bracket values. Example: 0,-0.7,-1.0
+TINY_FILM_CAPTURE_BRACKETS=
+TINY_FILM_CAPTURE_BRACKET_SETTLE_SECONDS=0.25
+# White balance mode: default, auto, incandescent, tungsten, fluorescent,
+# indoor, daylight, cloudy, or custom.
+TINY_FILM_CAPTURE_AWB_MODE=daylight
+# Set to 1 to let AWB settle during warmup, then lock it for the capture.
+TINY_FILM_CAPTURE_AWB_LOCK=0
 # Clockwise rotation applied to the saved JPEG pixels: 0, 90, 180, or 270.
-TINY_FILM_CAPTURE_ROTATION=90
+TINY_FILM_CAPTURE_ROTATION=270
 TINY_FILM_CAPTURE_WARMUP_SECONDS=0.5
 TINY_FILM_CAPTURE_FOCUS_MODE=continuous

--- a/README.md
+++ b/README.md
@@ -54,3 +54,23 @@ while the HAT is plugged into USB power.
 
 To change the button pin or capture settings, copy `.env.example` to `.env` and
 edit the `TINY_FILM_*` values.
+
+For a more film-friendly source capture, start by testing:
+
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --sharpness 0.3 \
+  --contrast 0.85 \
+  --saturation 0.9 \
+  --ev -0.7 \
+  --awb-mode daylight \
+  --rotation 270
+```
+
+For highlight safety, capture a bracket from one warmed-up camera session:
+
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --exposure-brackets 0,-0.7,-1.0 \
+  --awb-lock
+```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,6 +5,27 @@
 rpicam-still -o photo1.jpg --quality 95 --sharpness 0.5 --contrast 0.9 --saturation 0.9
 ```
 
+## Take a film-friendlier highlight-protected photo
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --output photo1.jpg \
+  --quality 95 \
+  --sharpness 0.3 \
+  --contrast 0.85 \
+  --saturation 0.9 \
+  --ev -0.7 \
+  --awb-mode daylight \
+  --rotation 270
+```
+
+## Take an exposure bracket
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --output photo1.jpg \
+  --exposure-brackets 0,-0.7,-1.0 \
+  --awb-lock
+```
+
 ## Take a photo with the Python capture code
 ```bash
 python3 src/tiny-film-cam/capture.py

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -26,11 +26,39 @@ For a Camera Module 3 full-size still, pass an explicit size:
 python3 src/tiny-film-cam/capture.py --width 4608 --height 2592
 ```
 
-The default image tuning matches the existing `rpicam-still` command:
+The default image tuning is set for a film-friendly source capture:
 
 ```text
-quality=95, sharpness=0.5, contrast=0.9, saturation=0.9
+quality=95, sharpness=0.3, contrast=0.85, saturation=0.9,
+ev=-0.7, awb_mode=daylight, rotation=270
 ```
+
+For a more film-friendly source capture, protect highlights and reduce digital
+edge bite:
+
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --width 4608 \
+  --height 2592 \
+  --sharpness 0.3 \
+  --contrast 0.85 \
+  --saturation 0.9 \
+  --ev -0.7 \
+  --awb-mode daylight \
+  --rotation 270
+```
+
+To capture multiple exposure candidates from one warmed-up camera session:
+
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --output photo1.jpg \
+  --exposure-brackets 0,-0.7,-1.0 \
+  --awb-lock
+```
+
+Bracketed filenames include the EV value, such as
+`photo1_ev+0p0.jpg`, `photo1_ev-0p7.jpg`, and `photo1_ev-1p0.jpg`.
 
 Run the capture browser:
 

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -11,10 +11,52 @@ from typing import Iterator, Literal
 
 Rotation = Literal[0, 90, 180, 270]
 FocusMode = Literal["default", "auto", "continuous", "manual"]
+AwbMode = Literal[
+    "default",
+    "auto",
+    "incandescent",
+    "tungsten",
+    "fluorescent",
+    "indoor",
+    "daylight",
+    "cloudy",
+    "custom",
+]
 ROTATIONS = {0, 90, 180, 270}
 FOCUS_MODES = {"default", "auto", "continuous", "manual"}
+AWB_MODES = {
+    "default",
+    "auto",
+    "incandescent",
+    "tungsten",
+    "fluorescent",
+    "indoor",
+    "daylight",
+    "cloudy",
+    "custom",
+}
+AWB_MODE_ENUM_NAMES = {
+    "auto": "Auto",
+    "incandescent": "Incandescent",
+    "tungsten": "Tungsten",
+    "fluorescent": "Fluorescent",
+    "indoor": "Indoor",
+    "daylight": "Daylight",
+    "cloudy": "Cloudy",
+    "custom": "Custom",
+}
 PICAMERA_ARRAY_FORMAT = "RGB888"
-DEFAULT_ROTATION: Rotation = 90
+DEFAULT_QUALITY = 95
+DEFAULT_SHARPNESS = 0.3
+DEFAULT_CONTRAST = 0.85
+DEFAULT_SATURATION = 0.9
+DEFAULT_EXPOSURE_VALUE = -0.7
+DEFAULT_BRACKET_SETTLE_SECONDS = 0.25
+DEFAULT_ROTATION: Rotation = 270
+DEFAULT_WARMUP_SECONDS = 0.5
+DEFAULT_FOCUS_MODE: FocusMode = "continuous"
+DEFAULT_AWB_MODE: AwbMode = "daylight"
+DEFAULT_AWB_LOCK = False
 
 
 class CameraCaptureError(RuntimeError):
@@ -31,14 +73,19 @@ class CaptureSettings:
     filename: str | None = None
     width: int | None = None
     height: int | None = None
-    quality: int = 95
-    sharpness: float = 0.5
-    contrast: float = 0.9
-    saturation: float = 0.9
+    quality: int = DEFAULT_QUALITY
+    sharpness: float = DEFAULT_SHARPNESS
+    contrast: float = DEFAULT_CONTRAST
+    saturation: float = DEFAULT_SATURATION
+    exposure_value: float = DEFAULT_EXPOSURE_VALUE
+    exposure_brackets: tuple[float, ...] = ()
+    bracket_settle_seconds: float = DEFAULT_BRACKET_SETTLE_SECONDS
     rotation: Rotation = DEFAULT_ROTATION
-    warmup_seconds: float = 0.5
-    focus_mode: FocusMode = "continuous"
+    warmup_seconds: float = DEFAULT_WARMUP_SECONDS
+    focus_mode: FocusMode = DEFAULT_FOCUS_MODE
     lens_position: float | None = None
+    awb_mode: AwbMode = DEFAULT_AWB_MODE
+    awb_lock: bool = DEFAULT_AWB_LOCK
 
 
 def env_float(name: str, default: float) -> float:
@@ -55,6 +102,13 @@ def env_int(name: str, default: int) -> int:
     return int(value)
 
 
+def env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
 def env_optional_int(name: str) -> int | None:
     value = os.environ.get(name)
     if value is None or value.strip() == "":
@@ -67,6 +121,13 @@ def env_optional_float(name: str) -> float | None:
     if value is None or value.strip() == "":
         return None
     return float(value)
+
+
+def env_float_tuple(name: str) -> tuple[float, ...]:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return ()
+    return tuple(float(part.strip()) for part in value.split(",") if part.strip())
 
 
 def resolve_project_path(project_root: Path, value: str | Path) -> Path:
@@ -82,9 +143,12 @@ def capture_output_dir_from_env(project_root: Path) -> Path:
 
 
 def capture_settings_from_env(project_root: Path) -> CaptureSettings:
-    focus_mode = os.environ.get("TINY_FILM_CAPTURE_FOCUS_MODE", "continuous")
+    focus_mode = os.environ.get("TINY_FILM_CAPTURE_FOCUS_MODE", DEFAULT_FOCUS_MODE)
     if focus_mode not in FOCUS_MODES:
-        focus_mode = "continuous"
+        focus_mode = DEFAULT_FOCUS_MODE
+    awb_mode = os.environ.get("TINY_FILM_CAPTURE_AWB_MODE", DEFAULT_AWB_MODE)
+    if awb_mode not in AWB_MODES:
+        awb_mode = DEFAULT_AWB_MODE
     rotation = env_int("TINY_FILM_CAPTURE_ROTATION", DEFAULT_ROTATION)
     if rotation not in ROTATIONS:
         rotation = DEFAULT_ROTATION
@@ -92,14 +156,24 @@ def capture_settings_from_env(project_root: Path) -> CaptureSettings:
         output_dir=capture_output_dir_from_env(project_root),
         width=env_optional_int("TINY_FILM_CAPTURE_WIDTH"),
         height=env_optional_int("TINY_FILM_CAPTURE_HEIGHT"),
-        quality=env_int("TINY_FILM_CAPTURE_QUALITY", 95),
-        sharpness=env_float("TINY_FILM_CAPTURE_SHARPNESS", 0.5),
-        contrast=env_float("TINY_FILM_CAPTURE_CONTRAST", 0.9),
-        saturation=env_float("TINY_FILM_CAPTURE_SATURATION", 0.9),
+        quality=env_int("TINY_FILM_CAPTURE_QUALITY", DEFAULT_QUALITY),
+        sharpness=env_float("TINY_FILM_CAPTURE_SHARPNESS", DEFAULT_SHARPNESS),
+        contrast=env_float("TINY_FILM_CAPTURE_CONTRAST", DEFAULT_CONTRAST),
+        saturation=env_float("TINY_FILM_CAPTURE_SATURATION", DEFAULT_SATURATION),
+        exposure_value=env_float("TINY_FILM_CAPTURE_EV", DEFAULT_EXPOSURE_VALUE),
+        exposure_brackets=env_float_tuple("TINY_FILM_CAPTURE_BRACKETS"),
+        bracket_settle_seconds=env_float(
+            "TINY_FILM_CAPTURE_BRACKET_SETTLE_SECONDS",
+            DEFAULT_BRACKET_SETTLE_SECONDS,
+        ),
         rotation=rotation,  # type: ignore[arg-type]
-        warmup_seconds=env_float("TINY_FILM_CAPTURE_WARMUP_SECONDS", 0.5),
+        warmup_seconds=env_float(
+            "TINY_FILM_CAPTURE_WARMUP_SECONDS", DEFAULT_WARMUP_SECONDS
+        ),
         focus_mode=focus_mode,  # type: ignore[arg-type]
         lens_position=env_optional_float("TINY_FILM_CAPTURE_LENS_POSITION"),
+        awb_mode=awb_mode,  # type: ignore[arg-type]
+        awb_lock=env_bool("TINY_FILM_CAPTURE_AWB_LOCK", DEFAULT_AWB_LOCK),
     )
 
 
@@ -122,6 +196,15 @@ def _timestamped_path(output_dir: Path) -> Path:
     return output_dir / date_dir / filename
 
 
+def _ev_suffix(exposure_value: float) -> str:
+    label = f"{exposure_value:+.1f}".replace(".", "p")
+    return f"ev{label}"
+
+
+def _path_with_stem_suffix(path: Path, stem_suffix: str) -> Path:
+    return path.with_name(f"{path.stem}_{stem_suffix}{path.suffix}")
+
+
 def _normalized_quality(value: int) -> int:
     return max(1, min(100, int(value)))
 
@@ -133,6 +216,20 @@ def _output_path(settings: CaptureSettings) -> Path:
         path = _timestamped_path(settings.output_dir.expanduser())
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def _exposure_values(settings: CaptureSettings) -> tuple[float, ...]:
+    if settings.exposure_brackets:
+        return settings.exposure_brackets
+    return (settings.exposure_value,)
+
+
+def _output_paths(settings: CaptureSettings) -> list[Path]:
+    path = _output_path(settings)
+    exposure_values = _exposure_values(settings)
+    if len(exposure_values) == 1:
+        return [path]
+    return [_path_with_stem_suffix(path, _ev_suffix(ev)) for ev in exposure_values]
 
 
 def _rotate_image(image, rotation: Rotation):
@@ -161,6 +258,7 @@ def _camera_controls(settings: CaptureSettings) -> dict[str, object]:
         "Sharpness": settings.sharpness,
         "Contrast": settings.contrast,
         "Saturation": settings.saturation,
+        "ExposureValue": settings.exposure_value,
     }
 
     try:
@@ -177,7 +275,22 @@ def _camera_controls(settings: CaptureSettings) -> dict[str, object]:
         if settings.lens_position is not None:
             controls["LensPosition"] = settings.lens_position
 
+    if settings.awb_mode != "default":
+        enum_name = AWB_MODE_ENUM_NAMES.get(settings.awb_mode)
+        enum_value = getattr(libcamera_controls.AwbModeEnum, enum_name, None)
+        if enum_value is not None:
+            controls["AwbMode"] = enum_value
+
     return controls
+
+
+def _apply_awb_lock(picam2, settings: CaptureSettings) -> None:
+    if settings.awb_lock:
+        picam2.set_controls({"AwbEnable": False})
+
+
+def _set_exposure_value(picam2, exposure_value: float) -> None:
+    picam2.set_controls({"ExposureValue": exposure_value})
 
 
 def _available_camera_count(Picamera2) -> int | None:
@@ -205,8 +318,8 @@ def _open_camera(Picamera2):
         ) from exc
 
 
-def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
-    """Capture one still image from a Raspberry Pi Camera Module 3."""
+def capture_photos(settings: CaptureSettings = CaptureSettings()) -> list[Path]:
+    """Capture one or more still images from a Raspberry Pi Camera Module 3."""
     import time
 
     try:
@@ -234,7 +347,8 @@ def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
             main=main_config,
             controls=_camera_controls(settings),
         )
-        output_path = _output_path(settings)
+        output_paths = _output_paths(settings)
+        exposure_values = _exposure_values(settings)
         started = False
 
         try:
@@ -243,14 +357,32 @@ def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
             started = True
             if settings.warmup_seconds > 0:
                 time.sleep(settings.warmup_seconds)
+            _apply_awb_lock(picam2, settings)
 
-            frame = picam2.capture_array("main")
+            for exposure_value, output_path in zip(
+                exposure_values, output_paths, strict=True
+            ):
+                if len(exposure_values) > 1 or exposure_value != settings.exposure_value:
+                    _set_exposure_value(picam2, exposure_value)
+                    if settings.bracket_settle_seconds > 0:
+                        time.sleep(settings.bracket_settle_seconds)
+
+                frame = picam2.capture_array("main")
+                image = _image_from_picamera_frame(frame)
+                image = _rotate_image(image, settings.rotation)
+                image.save(
+                    output_path,
+                    format="JPEG",
+                    quality=_normalized_quality(settings.quality),
+                )
         finally:
             if started:
                 picam2.stop()
             picam2.close()
 
-        image = _image_from_picamera_frame(frame)
-        image = _rotate_image(image, settings.rotation)
-        image.save(output_path, format="JPEG", quality=_normalized_quality(settings.quality))
-        return output_path
+        return output_paths
+
+
+def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
+    """Capture still image(s) and return the primary saved path."""
+    return capture_photos(settings)[0]

--- a/src/tiny-film-cam/capture.py
+++ b/src/tiny-film-cam/capture.py
@@ -3,7 +3,26 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from camera import CaptureSettings, capture_photo
+from camera import (
+    AWB_MODES,
+    CaptureSettings,
+    DEFAULT_AWB_LOCK,
+    DEFAULT_AWB_MODE,
+    DEFAULT_BRACKET_SETTLE_SECONDS,
+    DEFAULT_CONTRAST,
+    DEFAULT_EXPOSURE_VALUE,
+    DEFAULT_FOCUS_MODE,
+    DEFAULT_QUALITY,
+    DEFAULT_ROTATION,
+    DEFAULT_SATURATION,
+    DEFAULT_SHARPNESS,
+    DEFAULT_WARMUP_SECONDS,
+    capture_photos,
+)
+
+
+def parse_exposure_brackets(value: str) -> tuple[float, ...]:
+    return tuple(float(part.strip()) for part in value.split(",") if part.strip())
 
 
 def parse_args() -> argparse.Namespace:
@@ -22,33 +41,65 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--width", type=int, help="Optional still capture width.")
     parser.add_argument("--height", type=int, help="Optional still capture height.")
-    parser.add_argument("--quality", type=int, default=95, help="JPEG quality, 1-100.")
-    parser.add_argument("--sharpness", type=float, default=0.5)
-    parser.add_argument("--contrast", type=float, default=0.9)
-    parser.add_argument("--saturation", type=float, default=0.9)
+    parser.add_argument(
+        "--quality", type=int, default=DEFAULT_QUALITY, help="JPEG quality, 1-100."
+    )
+    parser.add_argument("--sharpness", type=float, default=DEFAULT_SHARPNESS)
+    parser.add_argument("--contrast", type=float, default=DEFAULT_CONTRAST)
+    parser.add_argument("--saturation", type=float, default=DEFAULT_SATURATION)
+    parser.add_argument(
+        "--ev",
+        type=float,
+        default=DEFAULT_EXPOSURE_VALUE,
+        help="Exposure compensation in stops, e.g. -0.7 to protect highlights.",
+    )
+    parser.add_argument(
+        "--exposure-brackets",
+        type=parse_exposure_brackets,
+        default=(),
+        help="Comma-separated EV values to capture, e.g. '0,-0.7,-1.0'.",
+    )
+    parser.add_argument(
+        "--bracket-settle-seconds",
+        type=float,
+        default=DEFAULT_BRACKET_SETTLE_SECONDS,
+        help="Seconds to let auto exposure settle between bracketed shots.",
+    )
     parser.add_argument(
         "--rotation",
         type=int,
         choices=(0, 90, 180, 270),
-        default=0,
+        default=DEFAULT_ROTATION,
         help="Rotate the saved JPEG clockwise after capture.",
     )
     parser.add_argument(
         "--warmup-seconds",
         type=float,
-        default=0.5,
+        default=DEFAULT_WARMUP_SECONDS,
         help="Seconds to let exposure/focus settle before capture.",
     )
     parser.add_argument(
         "--focus-mode",
         choices=("default", "auto", "continuous", "manual"),
-        default="continuous",
+        default=DEFAULT_FOCUS_MODE,
         help="Camera Module 3 focus mode.",
     )
     parser.add_argument(
         "--lens-position",
         type=float,
         help="Manual lens position. Only used with --focus-mode manual.",
+    )
+    parser.add_argument(
+        "--awb-mode",
+        choices=sorted(AWB_MODES),
+        default=DEFAULT_AWB_MODE,
+        help="White balance mode. Use daylight/cloudy/etc for more consistent grading.",
+    )
+    parser.add_argument(
+        "--awb-lock",
+        action="store_true",
+        default=DEFAULT_AWB_LOCK,
+        help="Let AWB settle during warmup, then lock it before capture.",
     )
     return parser.parse_args()
 
@@ -64,13 +115,19 @@ def main() -> None:
         sharpness=args.sharpness,
         contrast=args.contrast,
         saturation=args.saturation,
+        exposure_value=args.ev,
+        exposure_brackets=args.exposure_brackets,
+        bracket_settle_seconds=args.bracket_settle_seconds,
         rotation=args.rotation,
         warmup_seconds=args.warmup_seconds,
         focus_mode=args.focus_mode,
         lens_position=args.lens_position,
+        awb_mode=args.awb_mode,
+        awb_lock=args.awb_lock,
     )
-    output_path = capture_photo(settings)
-    print(f"Saved photo to {output_path}")
+    output_paths = capture_photos(settings)
+    for output_path in output_paths:
+        print(f"Saved photo to {output_path}")
 
 
 if __name__ == "__main__":

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -8,8 +8,9 @@ import threading
 from pathlib import Path
 
 from camera import (
+    AWB_MODES,
     CaptureSettings,
-    capture_photo,
+    capture_photos,
     capture_settings_from_env,
     resolve_project_path,
 )
@@ -37,6 +38,10 @@ def env_float(name: str, default: float) -> float:
     if value is None or value.strip() == "":
         return default
     return float(value)
+
+
+def parse_exposure_brackets(value: str) -> tuple[float, ...]:
+    return tuple(float(part.strip()) for part in value.split(",") if part.strip())
 
 
 def default_project_root() -> Path:
@@ -86,6 +91,21 @@ def parse_args() -> argparse.Namespace:
         default=capture_defaults.saturation,
     )
     parser.add_argument(
+        "--ev",
+        type=float,
+        default=capture_defaults.exposure_value,
+    )
+    parser.add_argument(
+        "--exposure-brackets",
+        type=parse_exposure_brackets,
+        default=capture_defaults.exposure_brackets,
+    )
+    parser.add_argument(
+        "--bracket-settle-seconds",
+        type=float,
+        default=capture_defaults.bracket_settle_seconds,
+    )
+    parser.add_argument(
         "--rotation",
         type=int,
         choices=(0, 90, 180, 270),
@@ -106,6 +126,21 @@ def parse_args() -> argparse.Namespace:
         "--lens-position",
         type=float,
         default=capture_defaults.lens_position,
+    )
+    parser.add_argument(
+        "--awb-mode",
+        choices=sorted(AWB_MODES),
+        default=capture_defaults.awb_mode,
+    )
+    parser.add_argument(
+        "--awb-lock",
+        action="store_true",
+        default=capture_defaults.awb_lock,
+    )
+    parser.add_argument(
+        "--no-awb-lock",
+        dest="awb_lock",
+        action="store_false",
     )
     return parser.parse_args()
 
@@ -148,13 +183,18 @@ def main() -> None:
                 sharpness=args.sharpness,
                 contrast=args.contrast,
                 saturation=args.saturation,
+                exposure_value=args.ev,
+                exposure_brackets=args.exposure_brackets,
+                bracket_settle_seconds=args.bracket_settle_seconds,
                 rotation=args.rotation,
                 warmup_seconds=args.warmup_seconds,
                 focus_mode=args.focus_mode,
                 lens_position=args.lens_position,
+                awb_mode=args.awb_mode,
+                awb_lock=args.awb_lock,
             )
-            output_path = capture_photo(settings)
-            LOGGER.info("Saved photo to %s", output_path)
+            output_paths = capture_photos(settings)
+            LOGGER.info("Saved %s photo(s): %s", len(output_paths), output_paths)
         except Exception:
             LOGGER.exception("Capture failed")
         finally:

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -42,11 +42,62 @@ def marker_image() -> Image.Image:
 
 
 class CameraRotationTest(unittest.TestCase):
-    def test_capture_settings_default_rotation_is_90(self) -> None:
+    def test_capture_settings_default_rotation_is_270(self) -> None:
         with patch.dict("os.environ", {}, clear=True):
             settings = camera.capture_settings_from_env(Path.cwd())
 
-        self.assertEqual(settings.rotation, 90)
+        self.assertEqual(settings.rotation, 270)
+
+    def test_capture_settings_default_film_source_controls(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            settings = camera.capture_settings_from_env(Path.cwd())
+
+        self.assertEqual(settings.sharpness, 0.3)
+        self.assertEqual(settings.contrast, 0.85)
+        self.assertEqual(settings.saturation, 0.9)
+        self.assertEqual(settings.exposure_value, -0.7)
+        self.assertEqual(settings.awb_mode, "daylight")
+        self.assertFalse(settings.awb_lock)
+
+    def test_capture_settings_reads_film_source_controls_from_env(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "TINY_FILM_CAPTURE_EV": "-0.7",
+                "TINY_FILM_CAPTURE_BRACKETS": "0,-0.7,-1.0",
+                "TINY_FILM_CAPTURE_BRACKET_SETTLE_SECONDS": "0.4",
+                "TINY_FILM_CAPTURE_AWB_MODE": "cloudy",
+                "TINY_FILM_CAPTURE_AWB_LOCK": "1",
+            },
+            clear=True,
+        ):
+            settings = camera.capture_settings_from_env(Path.cwd())
+
+        self.assertEqual(settings.exposure_value, -0.7)
+        self.assertEqual(settings.exposure_brackets, (0.0, -0.7, -1.0))
+        self.assertEqual(settings.bracket_settle_seconds, 0.4)
+        self.assertEqual(settings.awb_mode, "cloudy")
+        self.assertTrue(settings.awb_lock)
+
+    def test_bracket_output_paths_include_ev_suffixes(self) -> None:
+        settings = camera.CaptureSettings(
+            filename="photo.jpg",
+            exposure_brackets=(0.0, -0.7, -1.0),
+        )
+
+        paths = camera._output_paths(settings)
+
+        self.assertEqual(
+            [path.name for path in paths],
+            ["photo_ev+0p0.jpg", "photo_ev-0p7.jpg", "photo_ev-1p0.jpg"],
+        )
+
+    def test_camera_controls_include_exposure_value(self) -> None:
+        settings = camera.CaptureSettings(exposure_value=-0.7)
+
+        controls = camera._camera_controls(settings)
+
+        self.assertEqual(controls["ExposureValue"], -0.7)
 
     def test_picamera_frame_is_converted_from_bgr_to_rgb(self) -> None:
         frame = np.array(


### PR DESCRIPTION
## Summary
- add film-friendly capture defaults for lower sharpness/contrast, EV -0.7, daylight AWB, and 270-degree rotation
- add EV compensation, AWB mode/lock, and exposure bracket controls to CLI, env, and shutter daemon paths
- document Pi-side commands and add tests for defaults, env parsing, bracket filenames, and EV controls

## Validation
- python3 -m unittest discover -s tests
- python3 -m py_compile src/tiny-film-cam/camera.py src/tiny-film-cam/capture.py src/tiny-film-cam/shutter_daemon.py
