### PR TITLE
Add Printables source links for case assets

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,14 @@
+# 3D-printable case assets
+
+STL files for the tiny-film hardware enclosure.
+
+## Sources
+
+- https://www.printables.com/model/799255-raspberry-pi-zero-2-case-mk3-camera/files
+- https://www.printables.com/model/1546215-raspberry-pi-zero-2-wh-waveshare-ups-case/files
+
+## Files
+
+- `rpizerocase.stl` — base case
+- `Raspberry_Pi_Zero_2_Case_MK3_Camera_top.stl` — top cover
+- `Raspberry_Pi_Zero_2_Case_MK3_Camera_camera-suv-text.stl` — branded camera plate


### PR DESCRIPTION
## Summary
- Add `assets/README.md` with Printables source links for the camera case and Waveshare UPS case models
- Document the included STL files in the assets folder

## Test plan
- [ ] Links open to the correct Printables model pages


Made with [Cursor](https://cursor.com)