### PR TITLE
Prepare repo for public open source

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SuveenE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 My own digital film camera.
 
+Code and original CAD in this repo are [MIT](LICENSE). Third-party Printables
+case STLs keep their upstream Creative Commons licenses — see
+[assets/README.md](assets/README.md).
+
 ## Phone web app
 
 Run the local capture browser from the project root:

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,14 +1,37 @@
 # 3D-printable case assets
 
-STL files for the tiny-film hardware enclosure.
+STL and OpenSCAD files for the tiny-film hardware enclosure.
 
-## Sources
+Original project files in this folder (C-bracket spacers and generators) are
+covered by the repository [MIT License](../LICENSE). Third-party Printables
+models keep their upstream licenses, listed below.
 
-- https://www.printables.com/model/799255-raspberry-pi-zero-2-case-mk3-camera/files
-- https://www.printables.com/model/1546215-raspberry-pi-zero-2-wh-waveshare-ups-case/files
+## Third-party models
 
-## Files
+### Raspberry Pi Zero 2 Case MK3 Camera
 
-- `rpizerocase.stl` — base case
-- `Raspberry_Pi_Zero_2_Case_MK3_Camera_top.stl` — top cover
-- `Raspberry_Pi_Zero_2_Case_MK3_Camera_camera-suv-text.stl` — branded camera plate
+- **Designer:** [XenoTechie](https://www.printables.com/@XenoTechie_72441)
+- **Source:** https://www.printables.com/model/799255-raspberry-pi-zero-2-case-mk3-camera
+- **License:** [Creative Commons Attribution 4.0 (CC BY)](https://creativecommons.org/licenses/by/4.0/)
+- **Files in this repo:**
+  - `Raspberry_Pi_Zero_2_Case_MK3_Camera_top.stl` — top cover (unmodified)
+  - `Raspberry_Pi_Zero_2_Case_MK3_Camera_camera-suv-text.stl` — camera plate
+    remixed with custom “SUV” branding (derivative of the upstream camera
+    plate; redistributed under the same CC BY terms with attribution)
+
+### Raspberry Pi Zero 2 WH Waveshare UPS Case
+
+- **Designer:** [PiotrWolinski](https://www.printables.com/@PiotrWolinski_579340)
+- **Source:** https://www.printables.com/model/1546215-raspberry-pi-zero-2-wh-waveshare-ups-case
+- **License:** [Creative Commons Attribution-ShareAlike 4.0 (CC BY-SA)](https://creativecommons.org/licenses/by-sa/4.0/)
+- **Files in this repo:**
+  - `rpizerocase.stl` — base case (unmodified). ShareAlike applies to this
+    file and any adaptations of it.
+
+## Original project files
+
+- `c_bracket_spacer.scad` / `c_bracket_spacer.stl` — C-shaped corner spacer
+- `c_bracket_spacer_20mm.scad` / `c_bracket_spacer_20mm.stl` /
+  `c_bracket_spacer_20mm_2.1_2.8.stl` — 20 mm spacer variants
+- `generate_c_bracket.py` / `generate_c_bracket_20mm.py` — OpenSCAD helpers
+- `v0/v0-build.jpg` — photo of an assembled build

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,7 +38,7 @@ python3 src/tiny-film-cam/capture.py --width 4608 --height 2592
 
 ## Transfer photos to local machine
 ```bash
-scp -r suveen@172.20.10.2:/home/suveen/tiny-film/data/captures .
+scp -r <pi-user>@<pi-ip>:/home/<pi-user>/tiny-film/data/captures .
 ```
 
 ## Install boot services
@@ -69,9 +69,4 @@ curl http://localhost:8000/api/battery
 ## Follow service logs
 ```bash
 sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -u tiny-film-battery.service -f
-```
-
-## Apply an FCP-style look to an image
-```bash
-python3 src/tiny-film-cam/fcp_styles.py images/IMG_8025.jpg images --style claude_levels --compare
 ```

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -19,17 +19,18 @@ Expected: at least one camera is listed.
 If no camera appears, power down safely, reseat the camera ribbon, check the
 ribbon orientation, boot again, and rerun the check before testing the web app.
 
-## RPyConnect Not Detecting Pi
+## Pi Not Reachable Over the Network
 
-If RPyConnect stops working and isn't detecting the Pi, it's hard to tell when
-the Pi is back online. Fall back to SSH to check directly:
+If a remote tool or SSH client stops finding the Pi, check connectivity
+directly:
 
 ```bash
-ssh suveen@172.20.10.2
+ping <pi-ip>
+ssh <pi-user>@<pi-ip>
 ```
 
-If SSH itself is refused, make sure the SSH service is enabled and running on
-the Pi (one-time setup, requires a keyboard/monitor or another way in):
+If SSH is refused, make sure the SSH service is enabled and running on the Pi
+(one-time setup; needs a keyboard/monitor or another way in):
 
 ```bash
 sudo systemctl enable --now ssh


### PR DESCRIPTION
## Summary
- Add an MIT `LICENSE` for project code/CAD and document third-party Printables STL licenses (CC BY / CC BY-SA) in `assets/README.md`
- Sanitize personal SSH/SCP host details in docs and replace the RPyConnect section with a generic network-reachability guide
- Remove the stale `fcp_styles.py` command from docs

## Test plan
- [ ] Confirm README license links resolve (`LICENSE`, `assets/README.md`)
- [ ] Spot-check Printables attribution links and CC license URLs
- [ ] Confirm docs no longer contain personal usernames, IPs, or home paths
- [ ] Confirm `docs/commands.md` no longer references removed `fcp_styles.py`


Made with [Cursor](https://cursor.com)