### PR TITLE
Add optional feedback buzzer for shutter captures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ TINY_FILM_BUTTON_PIN=17
 TINY_FILM_BUTTON_PULL_UP=1
 TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 
+# Optional feedback buzzer. Leave TINY_FILM_BUZZER_PIN blank to disable sound.
+# Suggested wiring: buzzer "+" to BCM GPIO 18 (physical pin 12), "-" to GND.
+TINY_FILM_BUZZER_PIN=
+# 1 for a common active buzzer (on/off), 0 for a passive PWM-driven buzzer.
+TINY_FILM_BUZZER_ACTIVE=1
+
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95
 TINY_FILM_CAPTURE_SHARPNESS=0.3

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -1,0 +1,71 @@
+# Feedback Buzzer
+
+Add an optional buzzer so the camera chirps when the physical shutter button
+captures a photo. The buzzer is driven by the shutter daemon
+(`src/tiny-film-cam/shutter_daemon.py`):
+
+- **Two short high beeps** — capture saved successfully.
+- **One long low beep** — capture failed (check the logs).
+
+The buzzer is opt-in. With no pin configured, the shutter daemon behaves exactly
+as before and stays silent.
+
+## Choosing a buzzer
+
+- **Active buzzer** (most common, 3-pin or 2-pin "beeper" modules): has its own
+  oscillator, so it only needs to be switched on and off. Use `--buzzer-active`
+  (the default).
+- **Passive buzzer** (bare piezo element): needs a PWM tone to make sound. Use
+  `--buzzer-passive`.
+
+If you are unsure, an active buzzer module is the simplest choice.
+
+## Wiring
+
+The default uses BCM GPIO 18 (physical pin 12), which is free — the shutter
+button already uses GPIO 17.
+
+```
+Buzzer "+" / signal ──→ BCM GPIO 18 (physical pin 12)
+Buzzer "-" / GND     ──→ GND         (physical pin 14, or any GND)
+```
+
+Most small 3–5 V active buzzer breakout boards can be driven directly from a
+GPIO pin. For a bare passive piezo, put a ~100 Ω resistor in series with the
+signal line to limit current.
+
+## Enabling it
+
+Set the pin in `.env` (see `.env.example`):
+
+```bash
+TINY_FILM_BUZZER_PIN=18
+TINY_FILM_BUZZER_ACTIVE=1   # 0 for a passive buzzer
+```
+
+Then restart the shutter service:
+
+```bash
+sudo systemctl restart tiny-film-shutter.service
+```
+
+Or run the daemon directly with CLI flags:
+
+```bash
+python3 src/tiny-film-cam/shutter_daemon.py --buzzer-pin 18 --buzzer-active
+```
+
+## Configuration
+
+| Setting | Env var | CLI flag | Default |
+|---------|---------|----------|---------|
+| Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` | *(unset = disabled)* |
+| Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | active |
+
+## Notes
+
+- The buzzer is best-effort: if `gpiozero` is missing or the pin can't be
+  claimed, the daemon logs a warning and keeps capturing silently.
+- Only the physical shutter button path beeps. Web UI captures run in a separate
+  process and already show on-screen confirmation, so they don't share the pin.
+- Tones play on a background thread, so they never delay the next capture.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,7 +34,9 @@
 10. Wire the shutter button between BCM GPIO 17, physical pin 11, and any GND
    pin. With the default `.env.example` settings, the Pi uses its internal
    pull-up resistor.
-11. Install the Tiny Film boot services:
+11. (Optional) Wire a feedback buzzer so the camera chirps on capture. See
+   [buzzer.md](buzzer.md) for wiring and how to enable it.
+12. Install the Tiny Film boot services:
    ```bash
    ./scripts/install_service.sh --enable-now
    ```

--- a/docs/shutter-button.md
+++ b/docs/shutter-button.md
@@ -45,6 +45,11 @@ The service file is at `deploy/tiny-film-shutter.service`.
 All capture settings (quality, EV, rotation, AWB, etc.) are inherited from env
 vars or can be passed as CLI flags — run with `--help` for the full list.
 
+## Feedback buzzer
+
+For an audible confirmation on each press, wire an optional buzzer and enable it
+via `TINY_FILM_BUZZER_PIN`. See [buzzer.md](buzzer.md) for wiring and settings.
+
 ## Notes
 
 - Pressing the button while a capture is already in progress is ignored (no

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+LOGGER = logging.getLogger("tiny_film.buzzer")
+
+SUCCESS_FREQUENCY = 880.0
+ERROR_FREQUENCY = 220.0
+
+# Each step is (frequency_hz, on_seconds, gap_seconds_after). Frequency is only
+# used for passive buzzers; active buzzers just switch on and off.
+SUCCESS_PATTERN = (
+    (SUCCESS_FREQUENCY, 0.08, 0.06),
+    (SUCCESS_FREQUENCY, 0.08, 0.0),
+)
+ERROR_PATTERN = ((ERROR_FREQUENCY, 0.45, 0.0),)
+
+
+class ShutterBuzzer:
+    """Optional GPIO buzzer that chirps to confirm capture events.
+
+    The buzzer is best-effort: if gpiozero is missing or the device cannot be
+    claimed (nothing wired, pin in use, running off-Pi), it silently disables
+    itself so a capture is never blocked by sound feedback.
+    """
+
+    def __init__(self, pin: int | None, active: bool = True) -> None:
+        self._active = active
+        self._device = None
+        self._lock = threading.Lock()
+
+        if pin is None:
+            return
+
+        try:
+            if active:
+                from gpiozero import Buzzer
+
+                self._device = Buzzer(pin)
+            else:
+                from gpiozero import TonalBuzzer
+
+                # Widen the range so both the success and error tones are valid.
+                self._device = TonalBuzzer(pin, octaves=3)
+        except Exception:
+            LOGGER.exception(
+                "Could not set up buzzer on GPIO %s; captures will run without sound",
+                pin,
+            )
+            self._device = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._device is not None
+
+    def success(self) -> None:
+        self._play(SUCCESS_PATTERN)
+
+    def error(self) -> None:
+        self._play(ERROR_PATTERN)
+
+    def _play(self, pattern: tuple[tuple[float, float, float], ...]) -> None:
+        if self._device is None:
+            return
+        thread = threading.Thread(
+            target=self._run_pattern, args=(pattern,), daemon=True
+        )
+        thread.start()
+
+    def _run_pattern(self, pattern: tuple[tuple[float, float, float], ...]) -> None:
+        # Serialise playback so overlapping captures don't fight over the pin.
+        with self._lock:
+            try:
+                for frequency, on_seconds, gap_seconds in pattern:
+                    self._tone_on(frequency)
+                    time.sleep(on_seconds)
+                    self._tone_off()
+                    if gap_seconds:
+                        time.sleep(gap_seconds)
+            except Exception:
+                LOGGER.exception("Buzzer playback failed")
+                self._tone_off()
+
+    def _tone_on(self, frequency: float) -> None:
+        if self._device is None:
+            return
+        if self._active:
+            self._device.on()
+        else:
+            from gpiozero.tones import Tone
+
+            self._device.play(Tone(frequency=frequency))
+
+    def _tone_off(self) -> None:
+        if self._device is None:
+            return
+        if self._active:
+            self._device.off()
+        else:
+            self._device.stop()
+
+    def close(self) -> None:
+        if self._device is None:
+            return
+        try:
+            self._tone_off()
+            self._device.close()
+        except Exception:
+            LOGGER.exception("Buzzer close failed")
+        finally:
+            self._device = None

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -7,6 +7,7 @@ import signal
 import threading
 from pathlib import Path
 
+from buzzer import ShutterBuzzer
 from camera import (
     AWB_MODES,
     CaptureSettings,
@@ -30,6 +31,13 @@ def env_int(name: str, default: int) -> int:
     value = os.environ.get(name)
     if value is None or value.strip() == "":
         return default
+    return int(value)
+
+
+def env_optional_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
     return int(value)
 
 
@@ -63,6 +71,25 @@ def parse_args() -> argparse.Namespace:
         "--bounce-time",
         type=float,
         default=env_float("TINY_FILM_BUTTON_BOUNCE_SECONDS", 0.15),
+    )
+    parser.add_argument(
+        "--buzzer-pin",
+        type=int,
+        default=env_optional_int("TINY_FILM_BUZZER_PIN"),
+        help="BCM GPIO pin for an optional feedback buzzer. Omit to disable.",
+    )
+    parser.set_defaults(buzzer_active=env_bool("TINY_FILM_BUZZER_ACTIVE", True))
+    parser.add_argument(
+        "--buzzer-active",
+        dest="buzzer_active",
+        action="store_true",
+        help="Treat the buzzer as an active buzzer (simple on/off tone).",
+    )
+    parser.add_argument(
+        "--buzzer-passive",
+        dest="buzzer_active",
+        action="store_false",
+        help="Treat the buzzer as a passive buzzer driven with PWM tones.",
     )
     parser.add_argument(
         "--output-dir",
@@ -155,6 +182,7 @@ def main() -> None:
     output_dir = resolve_project_path(project_root, args.output_dir)
     capture_lock = threading.Lock()
     stop_event = threading.Event()
+    buzzer = ShutterBuzzer(args.buzzer_pin, active=args.buzzer_active)
 
     try:
         from gpiozero import Button
@@ -195,8 +223,10 @@ def main() -> None:
             )
             output_paths = capture_photos(settings)
             LOGGER.info("Saved %s photo(s): %s", len(output_paths), output_paths)
+            buzzer.success()
         except Exception:
             LOGGER.exception("Capture failed")
+            buzzer.error()
         finally:
             capture_lock.release()
 
@@ -213,12 +243,18 @@ def main() -> None:
     wiring = "GPIO-to-GND with pull-up" if args.pull_up else "GPIO-to-3V3 with pull-down"
     LOGGER.info("Tiny Film shutter ready on BCM GPIO %s (%s)", args.pin, wiring)
     LOGGER.info("Captures will be saved under %s", output_dir)
+    if buzzer.enabled:
+        buzzer_kind = "active" if args.buzzer_active else "passive"
+        LOGGER.info(
+            "Buzzer feedback on BCM GPIO %s (%s)", args.buzzer_pin, buzzer_kind
+        )
 
     try:
         while not stop_event.wait(1.0):
             pass
     finally:
         button.close()
+        buzzer.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+BUZZER_PATH = Path(__file__).resolve().parents[1] / "src" / "tiny-film-cam" / "buzzer.py"
+
+
+def load_buzzer_module():
+    spec = importlib.util.spec_from_file_location("tiny_film_buzzer", BUZZER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load buzzer module from {BUZZER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+buzzer = load_buzzer_module()
+
+
+class ShutterBuzzerTest(unittest.TestCase):
+    def test_no_pin_disables_buzzer(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+
+        self.assertFalse(device.enabled)
+        # Should be safe no-ops when disabled.
+        device.success()
+        device.error()
+        device.close()
+
+    def test_missing_gpiozero_degrades_gracefully(self) -> None:
+        # gpiozero is not installed off-Pi, so requesting a pin must not raise.
+        device = buzzer.ShutterBuzzer(18, active=True)
+
+        self.assertFalse(device.enabled)
+
+    def test_active_pattern_toggles_device_on_and_off(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        fake = MagicMock()
+        device._device = fake
+        device._active = True
+
+        device._run_pattern(((880.0, 0.0, 0.0),))
+
+        fake.on.assert_called_once_with()
+        fake.off.assert_called_once_with()
+
+    def test_close_releases_device(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        fake = MagicMock()
+        device._device = fake
+        device._active = True
+
+        device.close()
+
+        fake.close.assert_called_once_with()
+        self.assertFalse(device.enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds an optional GPIO buzzer that gives the physical shutter button audible confirmation: **two short high beeps** on a successful capture, **one long low beep** on failure.
- Opt-in via `TINY_FILM_BUZZER_PIN` (default disabled) and best-effort — a missing `gpiozero` or unwired pin logs a warning and never blocks a capture.
- Supports both **active** (on/off) and **passive** (PWM tone) buzzers; tones play on a background thread so they never delay the next shot.

## Changes
- `src/tiny-film-cam/buzzer.py` — new `ShutterBuzzer` class (graceful degradation, background playback, cleanup).
- `src/tiny-film-cam/shutter_daemon.py` — wires the buzzer into capture success/error, adds `--buzzer-pin` / `--buzzer-active` / `--buzzer-passive` flags and `TINY_FILM_BUZZER_PIN` / `TINY_FILM_BUZZER_ACTIVE` env vars.
- `.env.example`, `docs/buzzer.md` (new), `docs/shutter-button.md`, `docs/setup.md` — config + wiring docs (default pin GPIO 18, since GPIO 17 is the button).
- `tests/test_buzzer.py` — covers disabled/graceful-degrade/playback/cleanup.

## Notes
- Only the physical button path beeps; web/API captures run in a separate process (can't share the pin) and already show on-screen confirmation.

## Test plan
- [x] `python3 -m unittest discover -s tests` — all 18 tests pass.
- [ ] On the Pi: wire an active buzzer to GPIO 18 + GND, set `TINY_FILM_BUZZER_PIN=18`, restart `tiny-film-shutter.service`, and confirm beeps on button press (success) and on a forced failure.

Made with [Cursor](https://cursor.com)