### PR TITLE
Add short video recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ python3 src/tiny-film-cam/web.py
 ```
 
 Then open `http://<pi-ip>:8000` from a phone on the same Wi-Fi network.
-Tap **Take Photo** to capture from the phone.
+Tap **Take Photo** to capture a still, or **Record 10s** to capture a short
+video clip. Both appear in the gallery below.
 
 ## Boot services
 
@@ -45,8 +46,10 @@ sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -u tiny-fi
 
 The web service starts the phone app on port `8000`. The phone app and shutter
 service both save captures to `data/captures/`. The shutter service listens for
-a simple physical button on BCM GPIO 17 by default. Wire the button between BCM
-GPIO 17, physical pin 11, and any GND pin.
+a simple physical button on BCM GPIO 17 by default: tap it for a photo, or hold
+it to record a short video. Wire the button between BCM GPIO 17, physical pin 11,
+and any GND pin. Video recording (web, CLI, or shutter) needs `ffmpeg` installed
+on the Pi.
 
 The battery service polls the Waveshare UPS HAT (C) over I2C at address `0x43`
 and writes `data/battery.json`. The web app exposes the latest reading at

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,6 +36,16 @@ python3 src/tiny-film-cam/capture.py
 python3 src/tiny-film-cam/capture.py --width 4608 --height 2592
 ```
 
+## Record a short video (10s default)
+```bash
+python3 src/tiny-film-cam/record.py
+```
+
+## Record a custom-length video
+```bash
+python3 src/tiny-film-cam/record.py --duration 5 --width 1920 --height 1080 --fps 30
+```
+
 ## Transfer photos to local machine
 ```bash
 scp -r <pi-user>@<pi-ip>:/home/<pi-user>/tiny-film/data/captures .
@@ -64,6 +74,11 @@ sudo systemctl status tiny-film-web.service tiny-film-shutter.service tiny-film-
 ## Take a photo through the web server
 ```bash
 curl -X POST http://localhost:8000/api/capture
+```
+
+## Record a video through the web server
+```bash
+curl -X POST http://localhost:8000/api/record
 ```
 
 ## Read battery details through the web server

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,9 +18,13 @@
    ```bash
    rpicam-still -o test.jpg
    ```
-7. Install Python helpers:
+   Or record a short test clip:
    ```bash
-   sudo apt install -y python3-picamera2 python3-pil python3-gpiozero python3-smbus i2c-tools
+   rpicam-vid -t 5000 -o test.mp4
+   ```
+7. Install Python helpers (`ffmpeg` is required for MP4 video recording):
+   ```bash
+   sudo apt install -y python3-picamera2 python3-pil python3-gpiozero python3-smbus i2c-tools ffmpeg
    ```
 8. Enable I2C for the Waveshare UPS HAT (C):
    ```bash

--- a/docs/shutter-button.md
+++ b/docs/shutter-button.md
@@ -1,8 +1,11 @@
 # Shutter Button
 
-Wire a 4-pin momentary tactile switch to trigger photo capture from a physical
+Wire a 4-pin momentary tactile switch to trigger capture from a physical
 button. The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) listens for
 button presses and captures using the same settings as the web UI.
+
+**Tap** the button for a photo. **Hold** it (1s by default) to record a short
+video clip instead.
 
 ## Wiring
 
@@ -41,6 +44,8 @@ The service file is at `deploy/tiny-film-shutter.service`.
 | GPIO pin | `TINY_FILM_BUTTON_PIN` | `--pin` | 17 |
 | Pull direction | `TINY_FILM_BUTTON_PULL_UP` | `--pull-up` / `--pull-down` | pull-up |
 | Debounce time | `TINY_FILM_BUTTON_BOUNCE_SECONDS` | `--bounce-time` | 0.15 s |
+| Hold-to-record | — | `--hold-time` | 1.0 s |
+| Video length | — | `--video-duration` | 10 s |
 
 All capture settings (quality, EV, rotation, AWB, etc.) are inherited from env
 vars or can be passed as CLI flags — run with `--help` for the full list.
@@ -49,7 +54,9 @@ vars or can be passed as CLI flags — run with `--help` for the full list.
 
 - Pressing the button while a capture is already in progress is ignored (no
   double-fires).
-- Photos land in the same output directory as the web UI captures, so they
-  appear in the gallery immediately.
+- A hold long enough to start a video suppresses the photo that would otherwise
+  fire on release, so one long press yields exactly one clip.
+- Photos and videos land in the same output directory as the web UI captures, so
+  they appear in the gallery immediately.
 - If using pull-down wiring instead, connect the switch between GPIO and 3V3
   and pass `--pull-down`.

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -60,6 +60,16 @@ python3 src/tiny-film-cam/capture.py \
 Bracketed filenames include the EV value, such as
 `photo1_ev+0p0.jpg`, `photo1_ev-0p7.jpg`, and `photo1_ev-1p0.jpg`.
 
+Record a short video (H.264/MP4, 10s by default) into the same
+`data/captures/YYYY-MM-DD/` tree:
+
+```bash
+python3 src/tiny-film-cam/record.py --duration 10
+```
+
+Video recording requires `ffmpeg` on the Pi (`sudo apt install ffmpeg`) and only
+supports rotation 0 or 180.
+
 Run the capture browser:
 
 ```bash
@@ -71,6 +81,7 @@ The web app serves captures from `data/captures/` and exposes:
 - `GET /`
 - `GET /api/images`
 - `POST /api/capture`
+- `POST /api/record`
 - `DELETE /api/captures/<capture-path>`
 - `GET /image/captures/<capture-path>`
 - `GET /download/captures/<capture-path>`

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -57,6 +57,11 @@ DEFAULT_WARMUP_SECONDS = 0.5
 DEFAULT_FOCUS_MODE: FocusMode = "continuous"
 DEFAULT_AWB_MODE: AwbMode = "daylight"
 DEFAULT_AWB_LOCK = False
+DEFAULT_VIDEO_DURATION_SECONDS = 10.0
+DEFAULT_VIDEO_WIDTH = 1280
+DEFAULT_VIDEO_HEIGHT = 720
+DEFAULT_VIDEO_FPS = 30
+VIDEO_ONLY_ROTATIONS = {0, 180}
 
 
 class CameraCaptureError(RuntimeError):
@@ -80,6 +85,27 @@ class CaptureSettings:
     exposure_value: float = DEFAULT_EXPOSURE_VALUE
     exposure_brackets: tuple[float, ...] = ()
     bracket_settle_seconds: float = DEFAULT_BRACKET_SETTLE_SECONDS
+    rotation: Rotation = DEFAULT_ROTATION
+    warmup_seconds: float = DEFAULT_WARMUP_SECONDS
+    focus_mode: FocusMode = DEFAULT_FOCUS_MODE
+    lens_position: float | None = None
+    awb_mode: AwbMode = DEFAULT_AWB_MODE
+    awb_lock: bool = DEFAULT_AWB_LOCK
+
+
+@dataclass(frozen=True)
+class VideoSettings:
+    output_dir: Path = Path("data/captures")
+    filename: str | None = None
+    width: int = DEFAULT_VIDEO_WIDTH
+    height: int = DEFAULT_VIDEO_HEIGHT
+    fps: int = DEFAULT_VIDEO_FPS
+    duration_seconds: float = DEFAULT_VIDEO_DURATION_SECONDS
+    bitrate: int | None = None
+    sharpness: float = DEFAULT_SHARPNESS
+    contrast: float = DEFAULT_CONTRAST
+    saturation: float = DEFAULT_SATURATION
+    exposure_value: float = DEFAULT_EXPOSURE_VALUE
     rotation: Rotation = DEFAULT_ROTATION
     warmup_seconds: float = DEFAULT_WARMUP_SECONDS
     focus_mode: FocusMode = DEFAULT_FOCUS_MODE
@@ -177,6 +203,38 @@ def capture_settings_from_env(project_root: Path) -> CaptureSettings:
     )
 
 
+def video_settings_from_env(project_root: Path) -> VideoSettings:
+    focus_mode = os.environ.get("TINY_FILM_CAPTURE_FOCUS_MODE", DEFAULT_FOCUS_MODE)
+    if focus_mode not in FOCUS_MODES:
+        focus_mode = DEFAULT_FOCUS_MODE
+    awb_mode = os.environ.get("TINY_FILM_CAPTURE_AWB_MODE", DEFAULT_AWB_MODE)
+    if awb_mode not in AWB_MODES:
+        awb_mode = DEFAULT_AWB_MODE
+    rotation = env_int("TINY_FILM_CAPTURE_ROTATION", DEFAULT_ROTATION)
+    if rotation not in ROTATIONS:
+        rotation = DEFAULT_ROTATION
+    return VideoSettings(
+        output_dir=capture_output_dir_from_env(project_root),
+        width=DEFAULT_VIDEO_WIDTH,
+        height=DEFAULT_VIDEO_HEIGHT,
+        fps=DEFAULT_VIDEO_FPS,
+        duration_seconds=DEFAULT_VIDEO_DURATION_SECONDS,
+        bitrate=None,
+        sharpness=env_float("TINY_FILM_CAPTURE_SHARPNESS", DEFAULT_SHARPNESS),
+        contrast=env_float("TINY_FILM_CAPTURE_CONTRAST", DEFAULT_CONTRAST),
+        saturation=env_float("TINY_FILM_CAPTURE_SATURATION", DEFAULT_SATURATION),
+        exposure_value=env_float("TINY_FILM_CAPTURE_EV", DEFAULT_EXPOSURE_VALUE),
+        rotation=rotation,  # type: ignore[arg-type]
+        warmup_seconds=env_float(
+            "TINY_FILM_CAPTURE_WARMUP_SECONDS", DEFAULT_WARMUP_SECONDS
+        ),
+        focus_mode=focus_mode,  # type: ignore[arg-type]
+        lens_position=env_optional_float("TINY_FILM_CAPTURE_LENS_POSITION"),
+        awb_mode=awb_mode,  # type: ignore[arg-type]
+        awb_lock=env_bool("TINY_FILM_CAPTURE_AWB_LOCK", DEFAULT_AWB_LOCK),
+    )
+
+
 @contextmanager
 def _locked_camera(output_dir: Path) -> Iterator[None]:
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -193,6 +251,13 @@ def _timestamped_path(output_dir: Path) -> Path:
     captured_at = datetime.now()
     date_dir = captured_at.strftime("%Y-%m-%d")
     filename = f"{captured_at.strftime('%Y%m%d-%H%M%S-%f')}.jpg"
+    return output_dir / date_dir / filename
+
+
+def _video_timestamped_path(output_dir: Path) -> Path:
+    captured_at = datetime.now()
+    date_dir = captured_at.strftime("%Y-%m-%d")
+    filename = f"{captured_at.strftime('%Y%m%d-%H%M%S-%f')}.mp4"
     return output_dir / date_dir / filename
 
 
@@ -253,7 +318,7 @@ def _image_from_picamera_frame(frame):
     return Image.fromarray(rgb_frame, "RGB")
 
 
-def _camera_controls(settings: CaptureSettings) -> dict[str, object]:
+def _camera_controls(settings: "CaptureSettings | VideoSettings") -> dict[str, object]:
     controls: dict[str, object] = {
         "Sharpness": settings.sharpness,
         "Contrast": settings.contrast,
@@ -284,7 +349,7 @@ def _camera_controls(settings: CaptureSettings) -> dict[str, object]:
     return controls
 
 
-def _apply_awb_lock(picam2, settings: CaptureSettings) -> None:
+def _apply_awb_lock(picam2, settings: "CaptureSettings | VideoSettings") -> None:
     if settings.awb_lock:
         picam2.set_controls({"AwbEnable": False})
 
@@ -386,3 +451,97 @@ def capture_photos(settings: CaptureSettings = CaptureSettings()) -> list[Path]:
 def capture_photo(settings: CaptureSettings = CaptureSettings()) -> Path:
     """Capture still image(s) and return the primary saved path."""
     return capture_photos(settings)[0]
+
+
+def _video_output_path(settings: VideoSettings) -> Path:
+    if settings.filename:
+        path = Path(settings.filename).expanduser()
+    else:
+        path = _video_timestamped_path(settings.output_dir.expanduser())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _video_transform(rotation: Rotation):
+    """Return a libcamera Transform for the requested rotation, or None.
+
+    Video is captured through the hardware pipeline, so only the flips that
+    libcamera can apply in-sensor are supported (0 and 180 degrees). Other
+    rotations are ignored because they would require per-frame software work.
+    """
+    try:
+        from libcamera import Transform
+    except ImportError:
+        return None
+
+    if rotation == 180:
+        return Transform(hflip=1, vflip=1)
+    return Transform()
+
+
+def record_video(settings: VideoSettings = VideoSettings()) -> Path:
+    """Record a short H.264/MP4 clip from a Raspberry Pi Camera Module 3."""
+    import time
+
+    try:
+        from picamera2 import Picamera2
+    except ImportError as exc:
+        raise CameraCaptureError(
+            "Missing Picamera2. Install it on the Pi with "
+            "`sudo apt install python3-picamera2`."
+        ) from exc
+
+    try:
+        from picamera2.encoders import H264Encoder
+        from picamera2.outputs import FfmpegOutput
+    except ImportError as exc:
+        raise CameraCaptureError(
+            "Missing Picamera2 video encoders. Install ffmpeg on the Pi with "
+            "`sudo apt install ffmpeg`."
+        ) from exc
+
+    if settings.duration_seconds <= 0:
+        raise CameraCaptureError("Video duration must be greater than 0 seconds.")
+    if settings.rotation not in VIDEO_ONLY_ROTATIONS:
+        raise CameraCaptureError(
+            "Video recording only supports rotation 0 or 180. "
+            f"Got {settings.rotation}."
+        )
+
+    with _locked_camera(settings.output_dir.expanduser()):
+        picam2 = _open_camera(Picamera2)
+        controls = _camera_controls(settings)
+        if settings.fps > 0:
+            controls["FrameRate"] = float(settings.fps)
+
+        config = picam2.create_video_configuration(
+            main={"size": (settings.width, settings.height)},
+            controls=controls,
+            transform=_video_transform(settings.rotation),
+        )
+        output_path = _video_output_path(settings)
+        encoder = (
+            H264Encoder(bitrate=settings.bitrate)
+            if settings.bitrate
+            else H264Encoder()
+        )
+        output = FfmpegOutput(str(output_path))
+        started = False
+
+        try:
+            picam2.configure(config)
+            picam2.start()
+            started = True
+            if settings.warmup_seconds > 0:
+                time.sleep(settings.warmup_seconds)
+            _apply_awb_lock(picam2, settings)
+
+            picam2.start_recording(encoder, output)
+            time.sleep(settings.duration_seconds)
+            picam2.stop_recording()
+        finally:
+            if started:
+                picam2.stop()
+            picam2.close()
+
+        return output_path

--- a/src/tiny-film-cam/record.py
+++ b/src/tiny-film-cam/record.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from camera import (
+    AWB_MODES,
+    DEFAULT_AWB_LOCK,
+    DEFAULT_AWB_MODE,
+    DEFAULT_CONTRAST,
+    DEFAULT_EXPOSURE_VALUE,
+    DEFAULT_FOCUS_MODE,
+    DEFAULT_ROTATION,
+    DEFAULT_SATURATION,
+    DEFAULT_SHARPNESS,
+    DEFAULT_VIDEO_DURATION_SECONDS,
+    DEFAULT_VIDEO_FPS,
+    DEFAULT_VIDEO_HEIGHT,
+    DEFAULT_VIDEO_WIDTH,
+    DEFAULT_WARMUP_SECONDS,
+    VideoSettings,
+    record_video,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Record a short video with a Raspberry Pi Camera Module 3."
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output filename ending in .mp4, like rpicam-vid -o.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="data/captures",
+        help="Base directory for date-grouped timestamped output when --output is omitted.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=DEFAULT_VIDEO_DURATION_SECONDS,
+        help="Clip length in seconds.",
+    )
+    parser.add_argument("--width", type=int, default=DEFAULT_VIDEO_WIDTH)
+    parser.add_argument("--height", type=int, default=DEFAULT_VIDEO_HEIGHT)
+    parser.add_argument("--fps", type=int, default=DEFAULT_VIDEO_FPS)
+    parser.add_argument(
+        "--bitrate",
+        type=int,
+        help="H.264 bitrate in bits/sec. Omit for the encoder default.",
+    )
+    parser.add_argument("--sharpness", type=float, default=DEFAULT_SHARPNESS)
+    parser.add_argument("--contrast", type=float, default=DEFAULT_CONTRAST)
+    parser.add_argument("--saturation", type=float, default=DEFAULT_SATURATION)
+    parser.add_argument(
+        "--ev",
+        type=float,
+        default=DEFAULT_EXPOSURE_VALUE,
+        help="Exposure compensation in stops, e.g. -0.7 to protect highlights.",
+    )
+    parser.add_argument(
+        "--rotation",
+        type=int,
+        choices=(0, 180),
+        default=DEFAULT_ROTATION,
+        help="Rotate the recording. Video supports 0 or 180 only.",
+    )
+    parser.add_argument(
+        "--warmup-seconds",
+        type=float,
+        default=DEFAULT_WARMUP_SECONDS,
+        help="Seconds to let exposure/focus settle before recording.",
+    )
+    parser.add_argument(
+        "--focus-mode",
+        choices=("default", "auto", "continuous", "manual"),
+        default=DEFAULT_FOCUS_MODE,
+        help="Camera Module 3 focus mode.",
+    )
+    parser.add_argument(
+        "--lens-position",
+        type=float,
+        help="Manual lens position. Only used with --focus-mode manual.",
+    )
+    parser.add_argument(
+        "--awb-mode",
+        choices=sorted(AWB_MODES),
+        default=DEFAULT_AWB_MODE,
+        help="White balance mode.",
+    )
+    parser.add_argument(
+        "--awb-lock",
+        action="store_true",
+        default=DEFAULT_AWB_LOCK,
+        help="Let AWB settle during warmup, then lock it before recording.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    settings = VideoSettings(
+        output_dir=Path(args.output_dir),
+        filename=args.output,
+        width=args.width,
+        height=args.height,
+        fps=args.fps,
+        duration_seconds=args.duration,
+        bitrate=args.bitrate,
+        sharpness=args.sharpness,
+        contrast=args.contrast,
+        saturation=args.saturation,
+        exposure_value=args.ev,
+        rotation=args.rotation,
+        warmup_seconds=args.warmup_seconds,
+        focus_mode=args.focus_mode,
+        lens_position=args.lens_position,
+        awb_mode=args.awb_mode,
+        awb_lock=args.awb_lock,
+    )
+    output_path = record_video(settings)
+    print(f"Saved video to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -10,9 +10,12 @@ from pathlib import Path
 from camera import (
     AWB_MODES,
     CaptureSettings,
+    VideoSettings,
     capture_photos,
     capture_settings_from_env,
+    record_video,
     resolve_project_path,
+    video_settings_from_env,
 )
 
 
@@ -51,6 +54,7 @@ def default_project_root() -> Path:
 def parse_args() -> argparse.Namespace:
     project_root = default_project_root().expanduser().resolve()
     capture_defaults = capture_settings_from_env(project_root)
+    video_defaults = video_settings_from_env(project_root)
     parser = argparse.ArgumentParser(
         description="Run the Tiny Film physical shutter button listener."
     )
@@ -64,6 +68,21 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=env_float("TINY_FILM_BUTTON_BOUNCE_SECONDS", 0.15),
     )
+    parser.add_argument(
+        "--hold-time",
+        type=float,
+        default=1.0,
+        help="Seconds to hold the button before it records a video instead of a photo.",
+    )
+    parser.add_argument(
+        "--video-duration",
+        type=float,
+        default=video_defaults.duration_seconds,
+        help="Length in seconds of a held-button video clip.",
+    )
+    parser.add_argument("--video-width", type=int, default=video_defaults.width)
+    parser.add_argument("--video-height", type=int, default=video_defaults.height)
+    parser.add_argument("--video-fps", type=int, default=video_defaults.fps)
     parser.add_argument(
         "--output-dir",
         default=str(capture_defaults.output_dir),
@@ -155,6 +174,7 @@ def main() -> None:
     output_dir = resolve_project_path(project_root, args.output_dir)
     capture_lock = threading.Lock()
     stop_event = threading.Event()
+    held_flag = threading.Event()
 
     try:
         from gpiozero import Button
@@ -200,6 +220,45 @@ def main() -> None:
         finally:
             capture_lock.release()
 
+    def record_clip() -> None:
+        held_flag.set()
+        if not capture_lock.acquire(blocking=False):
+            LOGGER.info("Ignored button hold because a capture is already running")
+            return
+
+        try:
+            LOGGER.info("Button held; recording %.1fs video", args.video_duration)
+            settings = VideoSettings(
+                output_dir=output_dir,
+                width=args.video_width,
+                height=args.video_height,
+                fps=args.video_fps,
+                duration_seconds=args.video_duration,
+                sharpness=args.sharpness,
+                contrast=args.contrast,
+                saturation=args.saturation,
+                exposure_value=args.ev,
+                rotation=args.rotation,
+                warmup_seconds=args.warmup_seconds,
+                focus_mode=args.focus_mode,
+                lens_position=args.lens_position,
+                awb_mode=args.awb_mode,
+                awb_lock=args.awb_lock,
+            )
+            output_path = record_video(settings)
+            LOGGER.info("Saved video: %s", output_path)
+        except Exception:
+            LOGGER.exception("Recording failed")
+        finally:
+            capture_lock.release()
+
+    def on_release() -> None:
+        # A long hold already triggered a video via when_held; skip the photo.
+        if held_flag.is_set():
+            held_flag.clear()
+            return
+        take_photo()
+
     signal.signal(signal.SIGINT, request_stop)
     signal.signal(signal.SIGTERM, request_stop)
 
@@ -207,11 +266,18 @@ def main() -> None:
         args.pin,
         pull_up=args.pull_up,
         bounce_time=args.bounce_time if args.bounce_time > 0 else None,
+        hold_time=args.hold_time if args.hold_time > 0 else 1.0,
     )
-    button.when_pressed = take_photo
+    button.when_held = record_clip
+    button.when_released = on_release
 
     wiring = "GPIO-to-GND with pull-up" if args.pull_up else "GPIO-to-3V3 with pull-down"
     LOGGER.info("Tiny Film shutter ready on BCM GPIO %s (%s)", args.pin, wiring)
+    LOGGER.info(
+        "Tap to photograph; hold %.1fs to record a %.1fs video",
+        args.hold_time,
+        args.video_duration,
+    )
     LOGGER.info("Captures will be saved under %s", output_dir)
 
     try:

--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -18,10 +18,18 @@ from camera import (
     capture_output_dir_from_env,
     capture_photo,
     capture_settings_from_env,
+    record_video,
+    video_settings_from_env,
 )
 
 
-CAPTURE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
+VIDEO_SUFFIXES = {".mp4"}
+CAPTURE_SUFFIXES = IMAGE_SUFFIXES | VIDEO_SUFFIXES
+
+
+def media_type_for(path: Path) -> str:
+    return "video" if path.suffix.lower() in VIDEO_SUFFIXES else "image"
 
 
 def default_project_root() -> Path:
@@ -81,6 +89,7 @@ def build_capture_image_list(project_root: Path) -> list[dict[str, object]]:
             {
                 "filename": image_path.name,
                 "relative_path": relative_path,
+                "media_type": media_type_for(image_path),
                 "view_url": f"/image/captures/{quote(relative_path)}",
                 "download_url": f"/download/captures/{quote(relative_path)}",
                 "delete_url": f"/api/captures/{quote(relative_path)}",
@@ -98,6 +107,7 @@ def build_capture_image(project_root: Path, image_path: Path) -> dict[str, objec
     return {
         "filename": image_path.name,
         "relative_path": relative_path,
+        "media_type": media_type_for(image_path),
         "view_url": f"/image/captures/{quote(relative_path)}",
         "download_url": f"/download/captures/{quote(relative_path)}",
         "delete_url": f"/api/captures/{quote(relative_path)}",
@@ -113,6 +123,17 @@ def capture_from_web(project_root: Path) -> dict[str, object]:
     except ValueError as exc:
         raise RuntimeError(
             "Capture was saved outside the configured captures directory"
+        ) from exc
+    return build_capture_image(project_root, output_path)
+
+
+def record_from_web(project_root: Path) -> dict[str, object]:
+    output_path = record_video(video_settings_from_env(project_root))
+    try:
+        output_path.relative_to(captures_root(project_root))
+    except ValueError as exc:
+        raise RuntimeError(
+            "Recording was saved outside the configured captures directory"
         ) from exc
     return build_capture_image(project_root, output_path)
 
@@ -265,7 +286,8 @@ def render_page() -> bytes:
             place-items: center;
             overflow: hidden;
           }
-          .latest-frame img {
+          .latest-frame img,
+          .latest-frame video {
             display: block;
             width: 100%;
             max-height: 64vh;
@@ -365,7 +387,8 @@ def render_page() -> bytes:
             align-items: center;
             overflow: hidden;
           }
-          .capture-stage img {
+          .capture-stage img,
+          .capture-stage video {
             display: block;
             width: 100%;
             max-height: 62vh;
@@ -504,7 +527,10 @@ def render_page() -> bytes:
           <section class="latest">
             <div class="section-heading">
               <h2>Latest</h2>
-              <button class="button primary" id="capture-button" type="button">Take Photo</button>
+              <div class="actions">
+                <button class="button" id="record-button" type="button">Record 10s</button>
+                <button class="button primary" id="capture-button" type="button">Take Photo</button>
+              </div>
             </div>
             <div class="latest-frame" id="latest-frame"></div>
           </section>
@@ -538,6 +564,7 @@ def render_page() -> bytes:
           const batterySummary = document.getElementById("battery-summary");
           const batterySummaryPercent = document.getElementById("battery-summary-percent");
           const captureButton = document.getElementById("capture-button");
+          const recordButton = document.getElementById("record-button");
           let captureImages = [];
           let selectedCaptureIndex = 0;
 
@@ -629,9 +656,19 @@ def render_page() -> bytes:
               selectCapture(selectedCaptureIndex - 1);
             });
 
-            const preview = document.createElement("img");
-            preview.src = `${viewUrl}?v=${encodeURIComponent(image.modified_unix || "")}`;
-            preview.alt = image.filename || "Capture";
+            const previewSrc = `${viewUrl}?v=${encodeURIComponent(image.modified_unix || "")}`;
+            let preview;
+            if (image.media_type === "video") {
+              preview = document.createElement("video");
+              preview.src = previewSrc;
+              preview.controls = true;
+              preview.playsInline = true;
+              preview.preload = "metadata";
+            } else {
+              preview = document.createElement("img");
+              preview.src = previewSrc;
+              preview.alt = image.filename || "Capture";
+            }
 
             const nextButton = makeIconButton("button", "next", "Next capture");
             nextButton.disabled = selectedCaptureIndex === captureImages.length - 1;
@@ -690,10 +727,21 @@ def render_page() -> bytes:
             statusElement.textContent = `${images.length} capture${images.length === 1 ? "" : "s"}`;
             latestFrame.innerHTML = "";
             if (images.length) {
-              const image = document.createElement("img");
-              image.src = `/latest-image?v=${encodeURIComponent(images[0].modified_unix)}`;
-              image.alt = images[0].filename || "Latest capture";
-              latestFrame.appendChild(image);
+              const latest = images[0];
+              const cacheBust = encodeURIComponent(latest.modified_unix || "");
+              if (latest.media_type === "video") {
+                const video = document.createElement("video");
+                video.src = `${latest.view_url}?v=${cacheBust}`;
+                video.controls = true;
+                video.playsInline = true;
+                video.preload = "metadata";
+                latestFrame.appendChild(video);
+              } else {
+                const image = document.createElement("img");
+                image.src = `/latest-image?v=${cacheBust}`;
+                image.alt = latest.filename || "Latest capture";
+                latestFrame.appendChild(image);
+              }
             } else {
               latestFrame.innerHTML = '<div class="empty">No captures yet.</div>';
             }
@@ -829,7 +877,9 @@ def render_page() -> bytes:
 
           async function takePhoto() {
             if (captureButton.disabled) return;
+            const wasRecordDisabled = recordButton.disabled;
             captureButton.disabled = true;
+            recordButton.disabled = true;
             captureButton.textContent = "Taking...";
             statusElement.textContent = "Taking photo...";
             try {
@@ -849,12 +899,45 @@ def render_page() -> bytes:
               statusElement.textContent = error instanceof Error ? error.message : "Capture failed";
             } finally {
               captureButton.disabled = false;
+              recordButton.disabled = wasRecordDisabled;
               captureButton.textContent = "Take Photo";
+            }
+          }
+
+          async function recordVideo() {
+            if (recordButton.disabled) return;
+            const wasCaptureDisabled = captureButton.disabled;
+            recordButton.disabled = true;
+            captureButton.disabled = true;
+            recordButton.textContent = "Recording...";
+            statusElement.textContent = "Recording video...";
+            try {
+              const response = await fetch("/api/record", {
+                method: "POST",
+                cache: "no-store",
+              });
+              const data = await response.json().catch(() => ({}));
+              if (!response.ok) {
+                throw new Error(data.error || "Recording failed");
+              }
+              await refreshImages({ selectLatest: true });
+              await refreshDetails();
+              const savedPath = data.image && data.image.relative_path ? data.image.relative_path : "video";
+              statusElement.textContent = `Saved ${savedPath}`;
+            } catch (error) {
+              statusElement.textContent = error instanceof Error ? error.message : "Recording failed";
+            } finally {
+              recordButton.disabled = false;
+              captureButton.disabled = wasCaptureDisabled;
+              recordButton.textContent = "Record 10s";
             }
           }
 
           captureButton.addEventListener("click", () => {
             takePhoto();
+          });
+          recordButton.addEventListener("click", () => {
+            recordVideo();
           });
           refreshImages().catch(() => {
             statusElement.textContent = "Could not load captures.";
@@ -1020,6 +1103,29 @@ def build_handler(project_root: Path, port: int):
                     )
                     return
                 self._send_json({"ok": True, "image": image})
+                return
+            if request_path == "/api/record":
+                try:
+                    media = record_from_web(project_root)
+                except CameraUnavailableError as exc:
+                    self._send_json(
+                        {"ok": False, "error": f"Recording failed: {exc}"},
+                        status=HTTPStatus.SERVICE_UNAVAILABLE,
+                    )
+                    return
+                except CameraCaptureError as exc:
+                    self._send_json(
+                        {"ok": False, "error": f"Recording failed: {exc}"},
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                    return
+                except Exception as exc:
+                    self._send_json(
+                        {"ok": False, "error": f"Recording failed: {exc}"},
+                        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                    return
+                self._send_json({"ok": True, "image": media})
                 return
             self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
 


### PR DESCRIPTION
## Summary

Adds short **H.264/MP4 video recording** to the camera, which was previously photo-only. Video capture is wired into every capture path and reuses the existing film-friendly image tuning (sharpness, contrast, saturation, EV, AWB, focus, rotation).

Defaults: **10s**, **1280×720**, **30fps** (all overridable via CLI flags).

## Changes

- **`camera.py`** — new `VideoSettings` dataclass + `record_video()` using Picamera2 `create_video_configuration` + `H264Encoder` + `FfmpegOutput`. Video-only rotation (0/180) via libcamera `Transform`. Adds `video_settings_from_env()`.
- **`record.py`** — new CLI entry point (`python3 src/tiny-film-cam/record.py`).
- **`web.py`** — `POST /api/record` endpoint, media-aware gallery (lists/serves/deletes `.mp4`), and a **Record 10s** button with inline `<video>` playback for the latest and browsed clips.
- **`shutter_daemon.py`** — tap = photo, **hold (1s) = record a clip**; the hold suppresses the release photo so one press yields one clip.
- **docs / READMEs / setup** — document the new commands, endpoint, shutter behavior, and the `ffmpeg` dependency.

## Notes

- Video recording requires `ffmpeg` on the Pi (`sudo apt install ffmpeg`).
- Video rotation only supports 0 or 180 (hardware pipeline limitation); other rotations raise a clear error.
- Hold time and video defaults are hardcoded (not env vars) but still overridable via CLI flags.

## Testing

- All modules pass `py_compile`; no linter errors. Not run on-device (no Pi/camera in this environment).

Made with [Cursor](https://cursor.com)