### PR TITLE
Add passive buzzer feedback for shutter captures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ TINY_FILM_BUTTON_PIN=17
 TINY_FILM_BUTTON_PULL_UP=1
 TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 
+# Optional feedback buzzer. Leave TINY_FILM_BUZZER_PIN blank to disable sound.
+# Suggested wiring: VCC→3V3, GND→GND, I/O→BCM GPIO 18 (physical pin 12).
+TINY_FILM_BUZZER_PIN=
+# 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
+TINY_FILM_BUZZER_ACTIVE=0
+
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95
 TINY_FILM_CAPTURE_SHARPNESS=0.3

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The web service starts the phone app on port `8000`. The phone app and shutter
 service both save captures to `data/captures/`. The shutter service listens for
 a simple physical button on BCM GPIO 17 by default: tap it for a photo, or hold
 it to record a short video. Wire the button between BCM GPIO 17, physical pin 11,
-and any GND pin. Video recording (web, CLI, or shutter) needs `ffmpeg` installed
-on the Pi.
+and any GND pin. An optional passive buzzer on BCM GPIO 18 can chirp for shutter
+events — see [docs/buzzer.md](docs/buzzer.md). Video recording (web, CLI, or
+shutter) needs `ffmpeg` installed on the Pi.
 
 The battery service polls the Waveshare UPS HAT (C) over I2C at address `0x43`
 and writes `data/battery.json`. The web app exposes the latest reading at

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -1,0 +1,88 @@
+# Feedback Buzzer
+
+Add an optional passive buzzer so the physical shutter gives audible cues.
+The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
+
+| Sound | When |
+|-------|------|
+| **click** | Shutter button fires (photo or video) |
+| **beep** | Photo saved |
+| **chirp** | Video recording started |
+| **double** | Video saved |
+| **alert** | Capture or recording failed |
+
+The buzzer is opt-in. With no pin configured, the shutter daemon stays silent.
+
+## Hardware
+
+This project uses a **passive** buzzer module (PWM-driven, not an active beeper
+with a built-in oscillator). The BOM lists the module with pins **VCC**, **I/O**,
+and **GND**.
+
+## Wiring
+
+Avoid BCM GPIO 17 (shutter button) and BCM GPIO 2/3 (UPS HAT I2C). Use
+**BCM GPIO 18** (physical pin 12):
+
+```
+Buzzer VCC ──→ 3V3          (physical pin 1 or 17)
+Buzzer GND ──→ GND          (physical pin 6 or 14)
+Buzzer I/O ──→ BCM GPIO 18  (physical pin 12)
+```
+
+Power the module from **3.3V**, not 5V — the Pi GPIO is 3.3V and matches the
+module's 3.3–5.5V supply range.
+
+## Test the five sounds
+
+With the module wired, run the demo from the project root on the Pi:
+
+```bash
+python3 src/tiny-film-cam/buzzer.py
+```
+
+Or play one sound:
+
+```bash
+python3 src/tiny-film-cam/buzzer.py --sound beep
+```
+
+Default pin is BCM 18. Override with `--pin` if needed. Use `--active` only if
+you wired a simple on/off active buzzer instead.
+
+## Enabling it for the shutter
+
+Set the pin in `.env` (see `.env.example`):
+
+```bash
+TINY_FILM_BUZZER_PIN=18
+TINY_FILM_BUZZER_ACTIVE=0   # 0 = passive PWM (this module), 1 = active
+```
+
+Then restart the shutter service:
+
+```bash
+sudo systemctl restart tiny-film-shutter.service
+```
+
+Or run the daemon directly:
+
+```bash
+python3 src/tiny-film-cam/shutter_daemon.py --buzzer-pin 18 --buzzer-passive
+```
+
+## Configuration
+
+| Setting | Env var | CLI flag | Default |
+|---------|---------|----------|---------|
+| Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` | *(unset = disabled)* |
+| Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
+
+## Notes
+
+- The buzzer is best-effort: if `gpiozero` is missing or the pin can't be
+  claimed, the daemon logs a warning and keeps capturing silently.
+- Only the physical shutter path beeps. Web UI captures already show on-screen
+  confirmation and run in a separate process.
+- Tones play on a background thread, so they never delay the next capture.
+- Stay near **1.5–2.5 kHz** for this module; that is its claimed tone range.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,6 +56,16 @@ Example (Pi over phone hotspot):
 scp -r suveen@172.20.10.2:/home/suveen/tiny-film/data/captures .
 ```
 
+## Test the feedback buzzer (five sounds)
+```bash
+python3 src/tiny-film-cam/buzzer.py
+```
+
+## Play one buzzer sound
+```bash
+python3 src/tiny-film-cam/buzzer.py --sound beep
+```
+
 ## Install boot services
 ```bash
 ./scripts/install_service.sh --enable-now

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,7 +38,11 @@
 10. Wire the shutter button between BCM GPIO 17, physical pin 11, and any GND
    pin. With the default `.env.example` settings, the Pi uses its internal
    pull-up resistor.
-11. Install the Tiny Film boot services:
+11. Optionally wire the passive buzzer: VCC to 3V3, GND to GND, and I/O to
+    BCM GPIO 18 (physical pin 12). Set `TINY_FILM_BUZZER_PIN=18` in `.env`,
+    then test with `python3 src/tiny-film-cam/buzzer.py`. See
+    [buzzer.md](buzzer.md).
+12. Install the Tiny Film boot services:
    ```bash
    ./scripts/install_service.sh --enable-now
    ```

--- a/docs/shutter-button.md
+++ b/docs/shutter-button.md
@@ -50,6 +50,9 @@ The service file is at `deploy/tiny-film-shutter.service`.
 All capture settings (quality, EV, rotation, AWB, etc.) are inherited from env
 vars or can be passed as CLI flags — run with `--help` for the full list.
 
+For optional audible feedback from a passive buzzer module, see
+[buzzer.md](buzzer.md).
+
 ## Notes
 
 - Pressing the button while a capture is already in progress is ignored (no

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import threading
+import time
+
+LOGGER = logging.getLogger("tiny_film.buzzer")
+
+# Passive module sweet spot is roughly 1.5–2.5 kHz.
+# Each pattern step is (frequency_hz, on_seconds, gap_seconds_after).
+# Frequency is ignored for active buzzers (simple on/off).
+SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
+    "click": ((1800.0, 0.06, 0.0),),
+    "beep": ((2000.0, 0.15, 0.0),),
+    "chirp": ((2200.0, 0.10, 0.0),),
+    "alert": ((2400.0, 0.25, 0.0),),
+    "double": ((1600.0, 0.08, 0.05), (1600.0, 0.08, 0.0)),
+}
+
+SOUND_ORDER = ("click", "beep", "chirp", "alert", "double")
+
+
+class ShutterBuzzer:
+    """Optional GPIO buzzer for shutter feedback.
+
+    Best-effort: if gpiozero is missing or the pin cannot be claimed, the
+    buzzer disables itself so captures are never blocked by sound feedback.
+    """
+
+    def __init__(self, pin: int | None, active: bool = False) -> None:
+        self._active = active
+        self._device = None
+        self._lock = threading.Lock()
+
+        if pin is None:
+            return
+
+        try:
+            if active:
+                from gpiozero import Buzzer
+
+                self._device = Buzzer(pin)
+            else:
+                from gpiozero import TonalBuzzer
+                from gpiozero.tones import Tone
+
+                # Centre the PWM range on the module's 1.5–2.5 kHz band.
+                self._device = TonalBuzzer(pin, mid_tone=Tone(2000), octaves=1)
+        except Exception:
+            LOGGER.exception(
+                "Could not set up buzzer on GPIO %s; captures will run without sound",
+                pin,
+            )
+            self._device = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._device is not None
+
+    def click(self) -> None:
+        """Short tick when the shutter button fires."""
+        self.play("click")
+
+    def photo_ok(self) -> None:
+        """Confirmation that a photo was saved."""
+        self.play("beep")
+
+    def video_start(self) -> None:
+        """Cue that video recording has started."""
+        self.play("chirp")
+
+    def video_stop(self) -> None:
+        """Cue that video recording finished and was saved."""
+        self.play("double")
+
+    def error(self) -> None:
+        """Alert tone when capture or recording fails."""
+        self.play("alert")
+
+    def play(self, name: str) -> None:
+        pattern = SOUNDS.get(name)
+        if pattern is None:
+            raise ValueError(f"Unknown buzzer sound: {name!r}")
+        self._play(pattern)
+
+    def play_all(self, pause_seconds: float = 0.4) -> None:
+        """Play every built-in sound once — useful for hardware bring-up."""
+        for name in SOUND_ORDER:
+            LOGGER.info("Playing buzzer sound %s", name)
+            self._run_pattern(SOUNDS[name])
+            if pause_seconds:
+                time.sleep(pause_seconds)
+
+    def _play(self, pattern: tuple[tuple[float, float, float], ...]) -> None:
+        if self._device is None:
+            return
+        thread = threading.Thread(
+            target=self._run_pattern, args=(pattern,), daemon=True
+        )
+        thread.start()
+
+    def _run_pattern(self, pattern: tuple[tuple[float, float, float], ...]) -> None:
+        # Serialise playback so overlapping captures don't fight over the pin.
+        with self._lock:
+            try:
+                for frequency, on_seconds, gap_seconds in pattern:
+                    self._tone_on(frequency)
+                    time.sleep(on_seconds)
+                    self._tone_off()
+                    if gap_seconds:
+                        time.sleep(gap_seconds)
+            except Exception:
+                LOGGER.exception("Buzzer playback failed")
+                self._tone_off()
+
+    def _tone_on(self, frequency: float) -> None:
+        if self._device is None:
+            return
+        if self._active:
+            self._device.on()
+        else:
+            from gpiozero.tones import Tone
+
+            self._device.play(Tone(frequency=frequency))
+
+    def _tone_off(self) -> None:
+        if self._device is None:
+            return
+        if self._active:
+            self._device.off()
+        else:
+            self._device.stop()
+
+    def close(self) -> None:
+        if self._device is None:
+            return
+        try:
+            self._tone_off()
+            self._device.close()
+        except Exception:
+            LOGGER.exception("Buzzer close failed")
+        finally:
+            self._device = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Test the Tiny Film passive (or active) feedback buzzer."
+    )
+    parser.add_argument(
+        "--pin",
+        type=int,
+        default=18,
+        help="BCM GPIO pin for the buzzer I/O line (default: 18).",
+    )
+    parser.set_defaults(active=False)
+    parser.add_argument(
+        "--passive",
+        dest="active",
+        action="store_false",
+        help="Drive a passive buzzer with PWM tones (default).",
+    )
+    parser.add_argument(
+        "--active",
+        dest="active",
+        action="store_true",
+        help="Drive an active buzzer with simple on/off.",
+    )
+    parser.add_argument(
+        "--sound",
+        choices=SOUND_ORDER,
+        help="Play a single named sound instead of the full demo.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = parse_args()
+    buzzer = ShutterBuzzer(args.pin, active=args.active)
+    if not buzzer.enabled:
+        raise SystemExit(
+            f"Could not open buzzer on BCM GPIO {args.pin}. "
+            "Check wiring and that python3-gpiozero is installed."
+        )
+
+    kind = "active" if args.active else "passive"
+    LOGGER.info("Testing %s buzzer on BCM GPIO %s", kind, args.pin)
+    try:
+        if args.sound:
+            buzzer._run_pattern(SOUNDS[args.sound])
+        else:
+            buzzer.play_all()
+    finally:
+        buzzer.close()
+    LOGGER.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -7,6 +7,7 @@ import signal
 import threading
 from pathlib import Path
 
+from buzzer import ShutterBuzzer
 from camera import (
     AWB_MODES,
     CaptureSettings,
@@ -33,6 +34,13 @@ def env_int(name: str, default: int) -> int:
     value = os.environ.get(name)
     if value is None or value.strip() == "":
         return default
+    return int(value)
+
+
+def env_optional_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
     return int(value)
 
 
@@ -67,6 +75,25 @@ def parse_args() -> argparse.Namespace:
         "--bounce-time",
         type=float,
         default=env_float("TINY_FILM_BUTTON_BOUNCE_SECONDS", 0.15),
+    )
+    parser.add_argument(
+        "--buzzer-pin",
+        type=int,
+        default=env_optional_int("TINY_FILM_BUZZER_PIN"),
+        help="BCM GPIO pin for an optional feedback buzzer. Omit to disable.",
+    )
+    parser.set_defaults(buzzer_active=env_bool("TINY_FILM_BUZZER_ACTIVE", False))
+    parser.add_argument(
+        "--buzzer-active",
+        dest="buzzer_active",
+        action="store_true",
+        help="Treat the buzzer as an active buzzer (simple on/off tone).",
+    )
+    parser.add_argument(
+        "--buzzer-passive",
+        dest="buzzer_active",
+        action="store_false",
+        help="Treat the buzzer as a passive buzzer driven with PWM tones (default).",
     )
     parser.add_argument(
         "--hold-time",
@@ -175,6 +202,7 @@ def main() -> None:
     capture_lock = threading.Lock()
     stop_event = threading.Event()
     held_flag = threading.Event()
+    buzzer = ShutterBuzzer(args.buzzer_pin, active=args.buzzer_active)
 
     try:
         from gpiozero import Button
@@ -195,6 +223,7 @@ def main() -> None:
 
         try:
             LOGGER.info("Button pressed; capturing photo")
+            buzzer.click()
             settings = CaptureSettings(
                 output_dir=output_dir,
                 width=args.width,
@@ -215,8 +244,10 @@ def main() -> None:
             )
             output_paths = capture_photos(settings)
             LOGGER.info("Saved %s photo(s): %s", len(output_paths), output_paths)
+            buzzer.photo_ok()
         except Exception:
             LOGGER.exception("Capture failed")
+            buzzer.error()
         finally:
             capture_lock.release()
 
@@ -228,6 +259,8 @@ def main() -> None:
 
         try:
             LOGGER.info("Button held; recording %.1fs video", args.video_duration)
+            buzzer.click()
+            buzzer.video_start()
             settings = VideoSettings(
                 output_dir=output_dir,
                 width=args.video_width,
@@ -247,8 +280,10 @@ def main() -> None:
             )
             output_path = record_video(settings)
             LOGGER.info("Saved video: %s", output_path)
+            buzzer.video_stop()
         except Exception:
             LOGGER.exception("Recording failed")
+            buzzer.error()
         finally:
             capture_lock.release()
 
@@ -279,12 +314,18 @@ def main() -> None:
         args.video_duration,
     )
     LOGGER.info("Captures will be saved under %s", output_dir)
+    if buzzer.enabled:
+        buzzer_kind = "active" if args.buzzer_active else "passive"
+        LOGGER.info(
+            "Buzzer feedback on BCM GPIO %s (%s)", args.buzzer_pin, buzzer_kind
+        )
 
     try:
         while not stop_event.wait(1.0):
             pass
     finally:
         button.close()
+        buzzer.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+BUZZER_PATH = Path(__file__).resolve().parents[1] / "src" / "tiny-film-cam" / "buzzer.py"
+
+
+def load_buzzer_module():
+    spec = importlib.util.spec_from_file_location("tiny_film_buzzer", BUZZER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load buzzer module from {BUZZER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+buzzer = load_buzzer_module()
+
+
+class ShutterBuzzerTest(unittest.TestCase):
+    def test_no_pin_disables_buzzer(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+
+        self.assertFalse(device.enabled)
+        device.click()
+        device.photo_ok()
+        device.video_start()
+        device.video_stop()
+        device.error()
+        device.close()
+
+    def test_missing_gpiozero_degrades_gracefully(self) -> None:
+        # gpiozero is not installed off-Pi, so requesting a pin must not raise.
+        device = buzzer.ShutterBuzzer(18, active=False)
+
+        self.assertFalse(device.enabled)
+
+    def test_five_named_sounds_exist(self) -> None:
+        self.assertEqual(
+            tuple(buzzer.SOUND_ORDER),
+            ("click", "beep", "chirp", "alert", "double"),
+        )
+        for name in buzzer.SOUND_ORDER:
+            self.assertIn(name, buzzer.SOUNDS)
+
+    def test_pattern_calls_tone_helpers_in_order(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        device._device = MagicMock()
+        device._tone_on = MagicMock()
+        device._tone_off = MagicMock()
+
+        device._run_pattern(((2000.0, 0.0, 0.0), (1600.0, 0.0, 0.0)))
+
+        self.assertEqual(
+            [call.args[0] for call in device._tone_on.call_args_list],
+            [2000.0, 1600.0],
+        )
+        self.assertEqual(device._tone_off.call_count, 2)
+
+    def test_active_pattern_toggles_device_on_and_off(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        fake = MagicMock()
+        device._device = fake
+        device._active = True
+
+        device._run_pattern(((2000.0, 0.0, 0.0),))
+
+        fake.on.assert_called_once_with()
+        fake.off.assert_called_once_with()
+
+    def test_close_releases_device(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        fake = MagicMock()
+        device._device = fake
+        device._active = True
+
+        device.close()
+
+        fake.close.assert_called_once_with()
+        self.assertFalse(device.enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an optional PWM-driven passive buzzer on BCM GPIO 18 with five named sounds (click, beep, chirp, alert, double)
- Hook those cues into the shutter daemon for photo/video start/stop and failure feedback
- Document wiring, `.env` setup, and a demo CLI (`python3 src/tiny-film-cam/buzzer.py`) for hardware bring-up

## Test plan
- [ ] Wire passive buzzer: VCC→3V3, GND→GND, I/O→BCM GPIO 18
- [ ] Run `python3 src/tiny-film-cam/buzzer.py` and confirm all five tones play
- [ ] Set `TINY_FILM_BUZZER_PIN=18` and `TINY_FILM_BUZZER_ACTIVE=0` in `.env`
- [ ] Restart shutter service and tap button → click + beep on photo save
- [ ] Hold button for video → click + chirp at start, double on save
- [ ] Confirm captures still work with `TINY_FILM_BUZZER_PIN` left blank
- [ ] Run `python3 -m unittest tests.test_buzzer -v`


Made with [Cursor](https://cursor.com)