### PR TITLE
Default shutter buzzer to GPIO 18 passive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,10 @@ TINY_FILM_BUTTON_PIN=17
 TINY_FILM_BUTTON_PULL_UP=1
 TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 
-# Optional feedback buzzer. Leave TINY_FILM_BUZZER_PIN blank to disable sound.
-# Suggested wiring: VCC→3V3, GND→GND, I/O→BCM GPIO 18 (physical pin 12).
-TINY_FILM_BUZZER_PIN=
+# Feedback buzzer (defaults to BCM GPIO 18, passive — no .env needed).
+# Wiring: VCC→3V3, GND→GND, I/O→BCM GPIO 18 (physical pin 12).
+# Leave TINY_FILM_BUZZER_PIN blank to disable sound.
+TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ The web service starts the phone app on port `8000`. The phone app and shutter
 service both save captures to `data/captures/`. The shutter service listens for
 a simple physical button on BCM GPIO 17 by default: tap it for a photo, or hold
 it to record a short video. Wire the button between BCM GPIO 17, physical pin 11,
-and any GND pin. An optional passive buzzer on BCM GPIO 18 can chirp for shutter
-events — see [docs/buzzer.md](docs/buzzer.md). Video recording (web, CLI, or
-shutter) needs `ffmpeg` installed on the Pi.
+and any GND pin. A passive buzzer on BCM GPIO 18 is enabled by default for
+shutter feedback — see [docs/buzzer.md](docs/buzzer.md). Video recording (web,
+CLI, or shutter) needs `ffmpeg` installed on the Pi.
 
 The battery service polls the Waveshare UPS HAT (C) over I2C at address `0x43`
 and writes `data/battery.json`. The web app exposes the latest reading at

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -11,7 +11,8 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 | **double** | Video saved |
 | **alert** | Capture or recording failed |
 
-The buzzer is opt-in. With no pin configured, the shutter daemon stays silent.
+By default the shutter daemon uses a **passive** buzzer on **BCM GPIO 18**.
+Leave `TINY_FILM_BUZZER_PIN` blank in `.env`, or pass `--no-buzzer`, to disable.
 
 ## Hardware
 
@@ -50,16 +51,10 @@ python3 src/tiny-film-cam/buzzer.py --sound beep
 Default pin is BCM 18. Override with `--pin` if needed. Use `--active` only if
 you wired a simple on/off active buzzer instead.
 
-## Enabling it for the shutter
+## Using it with the shutter
 
-Set the pin in `.env` (see `.env.example`):
-
-```bash
-TINY_FILM_BUZZER_PIN=18
-TINY_FILM_BUZZER_ACTIVE=0   # 0 = passive PWM (this module), 1 = active
-```
-
-Then restart the shutter service:
+No `.env` entries are required for the default wiring (GPIO 18, passive).
+Restart the shutter service after deploying code that includes the buzzer:
 
 ```bash
 sudo systemctl restart tiny-film-shutter.service
@@ -68,14 +63,24 @@ sudo systemctl restart tiny-film-shutter.service
 Or run the daemon directly:
 
 ```bash
-python3 src/tiny-film-cam/shutter_daemon.py --buzzer-pin 18 --buzzer-passive
+python3 src/tiny-film-cam/shutter_daemon.py
+```
+
+To disable sound, leave the pin blank in `.env` or pass `--no-buzzer`:
+
+```bash
+TINY_FILM_BUZZER_PIN=
+```
+
+```bash
+python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 ```
 
 ## Configuration
 
 | Setting | Env var | CLI flag | Default |
 |---------|---------|----------|---------|
-| Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` | *(unset = disabled)* |
+| Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
 
 ## Notes

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,8 +39,8 @@
    pin. With the default `.env.example` settings, the Pi uses its internal
    pull-up resistor.
 11. Optionally wire the passive buzzer: VCC to 3V3, GND to GND, and I/O to
-    BCM GPIO 18 (physical pin 12). Set `TINY_FILM_BUZZER_PIN=18` in `.env`,
-    then test with `python3 src/tiny-film-cam/buzzer.py`. See
+    BCM GPIO 18 (physical pin 12). The shutter daemon enables that pin by
+    default — test with `python3 src/tiny-film-cam/buzzer.py`. See
     [buzzer.md](buzzer.md).
 12. Install the Tiny Film boot services:
    ```bash

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -37,9 +37,16 @@ def env_int(name: str, default: int) -> int:
     return int(value)
 
 
-def env_optional_int(name: str) -> int | None:
+def env_optional_int(name: str, default: int | None = None) -> int | None:
+    """Read an optional int env var.
+
+    Unset → ``default``. Explicit empty string → ``None`` (used to disable the
+    buzzer while keeping the code default of GPIO 18 when the var is absent).
+    """
     value = os.environ.get(name)
-    if value is None or value.strip() == "":
+    if value is None:
+        return default
+    if value.strip() == "":
         return None
     return int(value)
 
@@ -79,8 +86,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--buzzer-pin",
         type=int,
-        default=env_optional_int("TINY_FILM_BUZZER_PIN"),
-        help="BCM GPIO pin for an optional feedback buzzer. Omit to disable.",
+        default=env_optional_int("TINY_FILM_BUZZER_PIN", 18),
+        help="BCM GPIO pin for the feedback buzzer (default: 18). Use --no-buzzer to disable.",
+    )
+    parser.add_argument(
+        "--no-buzzer",
+        action="store_true",
+        help="Disable the feedback buzzer.",
     )
     parser.set_defaults(buzzer_active=env_bool("TINY_FILM_BUZZER_ACTIVE", False))
     parser.add_argument(
@@ -202,7 +214,8 @@ def main() -> None:
     capture_lock = threading.Lock()
     stop_event = threading.Event()
     held_flag = threading.Event()
-    buzzer = ShutterBuzzer(args.buzzer_pin, active=args.buzzer_active)
+    buzzer_pin = None if args.no_buzzer else args.buzzer_pin
+    buzzer = ShutterBuzzer(buzzer_pin, active=args.buzzer_active)
 
     try:
         from gpiozero import Button
@@ -317,8 +330,10 @@ def main() -> None:
     if buzzer.enabled:
         buzzer_kind = "active" if args.buzzer_active else "passive"
         LOGGER.info(
-            "Buzzer feedback on BCM GPIO %s (%s)", args.buzzer_pin, buzzer_kind
+            "Buzzer feedback on BCM GPIO %s (%s)", buzzer_pin, buzzer_kind
         )
+    elif args.no_buzzer or buzzer_pin is None:
+        LOGGER.info("Buzzer feedback disabled")
 
     try:
         while not stop_event.wait(1.0):


### PR DESCRIPTION
## Summary
- Shutter daemon now defaults to a passive buzzer on BCM GPIO 18 — no `.env` required for the standard wiring
- Explicit empty `TINY_FILM_BUZZER_PIN=` or `--no-buzzer` still disables sound
- Docs and `.env.example` updated to match

## Test plan
- [ ] On Pi with no buzzer env vars: restart shutter service and confirm logs show `Buzzer feedback on BCM GPIO 18 (passive)`
- [ ] Tap shutter → click + beep
- [ ] `python3 src/tiny-film-cam/buzzer.py` still plays the five demo tones
- [ ] With `TINY_FILM_BUZZER_PIN=` blank in `.env`, restart → log shows buzzer disabled
- [ ] If an older `.env` still has a blank `TINY_FILM_BUZZER_PIN=`, remove that line or set `18`


Made with [Cursor](https://cursor.com)