### PR TITLE
Add mechanical shutter click-clack buzzer cue

### DIFF
--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,11 +5,11 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **click** | Shutter button fires (photo or video) |
-| **beep** | Photo saved |
+| **shutter** | Photo capture (open/close click-clack) |
 | **chirp** | Video recording started |
 | **double** | Video saved |
 | **alert** | Capture or recording failed |
+| **click** / **beep** | Extra cues in the hardware demo |
 
 By default the shutter daemon uses a **passive** buzzer on **BCM GPIO 18**.
 Leave `TINY_FILM_BUZZER_PIN` blank in `.env`, or pass `--no-buzzer`, to disable.

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -34,7 +34,7 @@ Buzzer I/O ──→ BCM GPIO 18  (physical pin 12)
 Power the module from **3.3V**, not 5V — the Pi GPIO is 3.3V and matches the
 module's 3.3–5.5V supply range.
 
-## Test the five sounds
+## Test the sounds
 
 With the module wired, run the demo from the project root on the Pi:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,14 +56,14 @@ Example (Pi over phone hotspot):
 scp -r suveen@172.20.10.2:/home/suveen/tiny-film/data/captures .
 ```
 
-## Test the feedback buzzer (five sounds)
+## Test the feedback buzzer
 ```bash
 python3 src/tiny-film-cam/buzzer.py
 ```
 
-## Play one buzzer sound
+## Play the camera shutter sound
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound beep
+python3 src/tiny-film-cam/buzzer.py --sound shutter
 ```
 
 ## Install boot services

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -11,6 +11,8 @@ LOGGER = logging.getLogger("tiny_film.buzzer")
 # Each pattern step is (frequency_hz, on_seconds, gap_seconds_after).
 # Frequency is ignored for active buzzers (simple on/off).
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
+    # Two-step open/close approximation of a mechanical shutter.
+    "shutter": ((2000.0, 0.02, 0.012), (1550.0, 0.035, 0.0)),
     "click": ((1550.0, 0.06, 0.0),),
     "beep": ((1700.0, 0.15, 0.0),),
     "chirp": ((1850.0, 0.10, 0.0),),
@@ -18,7 +20,7 @@ SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
     "double": ((1500.0, 0.08, 0.05), (1500.0, 0.08, 0.0)),
 }
 
-SOUND_ORDER = ("click", "beep", "chirp", "alert", "double")
+SOUND_ORDER = ("shutter", "click", "beep", "chirp", "alert", "double")
 
 
 class ShutterBuzzer:
@@ -58,13 +60,17 @@ class ShutterBuzzer:
     def enabled(self) -> bool:
         return self._device is not None
 
+    def shutter(self) -> None:
+        """Mechanical shutter-like click-clack for a photo capture."""
+        self.play("shutter")
+
     def click(self) -> None:
         """Short tick when the shutter button fires."""
         self.play("click")
 
     def photo_ok(self) -> None:
         """Confirmation that a photo was saved."""
-        self.play("beep")
+        self.play("shutter")
 
     def video_start(self) -> None:
         """Cue that video recording has started."""

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -236,7 +236,7 @@ def main() -> None:
 
         try:
             LOGGER.info("Button pressed; capturing photo")
-            buzzer.click()
+            buzzer.shutter()
             settings = CaptureSettings(
                 output_dir=output_dir,
                 width=args.width,
@@ -257,7 +257,6 @@ def main() -> None:
             )
             output_paths = capture_photos(settings)
             LOGGER.info("Saved %s photo(s): %s", len(output_paths), output_paths)
-            buzzer.photo_ok()
         except Exception:
             LOGGER.exception("Capture failed")
             buzzer.error()
@@ -272,7 +271,6 @@ def main() -> None:
 
         try:
             LOGGER.info("Button held; recording %.1fs video", args.video_duration)
-            buzzer.click()
             buzzer.video_start()
             settings = VideoSettings(
                 output_dir=output_dir,

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -29,6 +29,7 @@ class ShutterBuzzerTest(unittest.TestCase):
         device = buzzer.ShutterBuzzer(None)
 
         self.assertFalse(device.enabled)
+        device.shutter()
         device.click()
         device.photo_ok()
         device.video_start()
@@ -57,13 +58,20 @@ class ShutterBuzzerTest(unittest.TestCase):
 
         self.assertFalse(device.enabled)
 
-    def test_five_named_sounds_exist(self) -> None:
+    def test_named_sounds_exist(self) -> None:
         self.assertEqual(
             tuple(buzzer.SOUND_ORDER),
-            ("click", "beep", "chirp", "alert", "double"),
+            ("shutter", "click", "beep", "chirp", "alert", "double"),
         )
         for name in buzzer.SOUND_ORDER:
             self.assertIn(name, buzzer.SOUNDS)
+
+    def test_shutter_pattern_is_two_step_click_clack(self) -> None:
+        pattern = buzzer.SOUNDS["shutter"]
+        self.assertEqual(len(pattern), 2)
+        self.assertGreater(pattern[0][0], pattern[1][0])
+        self.assertLess(pattern[0][1], 0.05)
+        self.assertLess(pattern[1][1], 0.05)
 
     def test_pattern_calls_tone_helpers_in_order(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary
- Add a two-step `shutter` tone pattern (short high tick + lower clack) that approximates a mechanical camera shutter on the passive buzzer
- Play it when the physical shutter takes a photo (instead of click + beep)
- Keep chirp/double/alert for video and errors; demo CLI can play `--sound shutter`

## Test plan
- [ ] `sudo systemctl stop tiny-film-shutter.service`
- [ ] `python3 src/tiny-film-cam/buzzer.py --sound shutter` — hear a quick click-clack
- [ ] Restart shutter service, tap button for a photo — same shutter cue
- [ ] Hold for video — chirp at start, double at end (unchanged)
- [ ] `python3 -m unittest tests.test_buzzer -v`


Made with [Cursor](https://cursor.com)