### PR TITLE
Soften passive buzzer cues with low PWM volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
+# Soft PWM duty cycle for passive buzzers (0.0–1.0). Raise toward 0.4 if too quiet.
+TINY_FILM_BUZZER_VOLUME=0.16
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -51,6 +51,12 @@ python3 src/tiny-film-cam/buzzer.py --sound beep
 Default pin is BCM 18. Override with `--pin` if needed. Use `--active` only if
 you wired a simple on/off active buzzer instead.
 
+Passive cues use a low PWM duty cycle so they stay soft. Try a quieter demo:
+
+```bash
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.12
+```
+
 ## Using it with the shutter
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
@@ -82,6 +88,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.16` |
 
 ## Notes
 

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -7,20 +7,27 @@ import time
 
 LOGGER = logging.getLogger("tiny_film.buzzer")
 
+# Soft default PWM duty cycle for passive buzzers (0.0–1.0). Full 0.5 is loud.
+DEFAULT_VOLUME = 0.16
+
 # Passive module sweet spot is roughly 1.5–2.5 kHz.
 # Each pattern step is (frequency_hz, on_seconds, gap_seconds_after).
 # Frequency is ignored for active buzzers (simple on/off).
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
-    # Two-step open/close approximation of a mechanical shutter.
-    "shutter": ((2000.0, 0.02, 0.012), (1550.0, 0.035, 0.0)),
-    "click": ((1550.0, 0.06, 0.0),),
-    "beep": ((1700.0, 0.15, 0.0),),
-    "chirp": ((1850.0, 0.10, 0.0),),
-    "alert": ((2000.0, 0.25, 0.0),),
-    "double": ((1500.0, 0.08, 0.05), (1500.0, 0.08, 0.0)),
+    # Soft open/close click-clack — short and quiet.
+    "shutter": ((1750.0, 0.014, 0.018), (1500.0, 0.022, 0.0)),
+    "click": ((1550.0, 0.035, 0.0),),
+    "beep": ((1600.0, 0.07, 0.0),),
+    "chirp": ((1700.0, 0.05, 0.0),),
+    "alert": ((1800.0, 0.10, 0.0),),
+    "double": ((1500.0, 0.04, 0.04), (1500.0, 0.04, 0.0)),
 }
 
 SOUND_ORDER = ("shutter", "click", "beep", "chirp", "alert", "double")
+
+
+def clamp_volume(volume: float) -> float:
+    return max(0.0, min(1.0, volume))
 
 
 class ShutterBuzzer:
@@ -28,10 +35,18 @@ class ShutterBuzzer:
 
     Best-effort: if gpiozero is missing or the pin cannot be claimed, the
     buzzer disables itself so captures are never blocked by sound feedback.
+
+    Passive buzzers are driven with a low PWM duty cycle so cues stay soft.
     """
 
-    def __init__(self, pin: int | None, active: bool = False) -> None:
+    def __init__(
+        self,
+        pin: int | None,
+        active: bool = False,
+        volume: float = DEFAULT_VOLUME,
+    ) -> None:
         self._active = active
+        self._volume = clamp_volume(volume)
         self._device = None
         self._lock = threading.Lock()
 
@@ -44,11 +59,10 @@ class ShutterBuzzer:
 
                 self._device = Buzzer(pin)
             else:
-                from gpiozero import TonalBuzzer
-                from gpiozero.tones import Tone
+                from gpiozero import PWMOutputDevice
 
-                # Centre the PWM range on the slightly lower cue tones.
-                self._device = TonalBuzzer(pin, mid_tone=Tone(1750), octaves=1)
+                # Duty-cycle volume: keep value at 0 until a tone plays.
+                self._device = PWMOutputDevice(pin, frequency=1600, initial_value=0)
         except Exception:
             LOGGER.exception(
                 "Could not set up buzzer on GPIO %s; captures will run without sound",
@@ -126,9 +140,8 @@ class ShutterBuzzer:
         if self._active:
             self._device.on()
         else:
-            from gpiozero.tones import Tone
-
-            self._device.play(Tone(frequency=frequency))
+            self._device.frequency = max(1.0, frequency)
+            self._device.value = self._volume
 
     def _tone_off(self) -> None:
         if self._device is None:
@@ -136,7 +149,7 @@ class ShutterBuzzer:
         if self._active:
             self._device.off()
         else:
-            self._device.stop()
+            self._device.value = 0
 
     def close(self) -> None:
         if self._device is None:
@@ -174,6 +187,12 @@ def parse_args() -> argparse.Namespace:
         help="Drive an active buzzer with simple on/off.",
     )
     parser.add_argument(
+        "--volume",
+        type=float,
+        default=DEFAULT_VOLUME,
+        help=f"Passive PWM duty cycle 0.0–1.0 (default: {DEFAULT_VOLUME}).",
+    )
+    parser.add_argument(
         "--sound",
         choices=SOUND_ORDER,
         help="Play a single named sound instead of the full demo.",
@@ -184,7 +203,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     args = parse_args()
-    buzzer = ShutterBuzzer(args.pin, active=args.active)
+    buzzer = ShutterBuzzer(args.pin, active=args.active, volume=args.volume)
     if not buzzer.enabled:
         raise SystemExit(
             f"Could not open buzzer on BCM GPIO {args.pin}. "
@@ -192,7 +211,12 @@ def main() -> None:
         )
 
     kind = "active" if args.active else "passive"
-    LOGGER.info("Testing %s buzzer on BCM GPIO %s", kind, args.pin)
+    LOGGER.info(
+        "Testing %s buzzer on BCM GPIO %s (volume=%.2f)",
+        kind,
+        args.pin,
+        clamp_volume(args.volume),
+    )
     try:
         if args.sound:
             buzzer._run_pattern(SOUNDS[args.sound])

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -108,6 +108,12 @@ def parse_args() -> argparse.Namespace:
         help="Treat the buzzer as a passive buzzer driven with PWM tones (default).",
     )
     parser.add_argument(
+        "--buzzer-volume",
+        type=float,
+        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.16),
+        help="Passive buzzer PWM duty cycle 0.0–1.0 (default: 0.16, softer).",
+    )
+    parser.add_argument(
         "--hold-time",
         type=float,
         default=1.0,
@@ -215,7 +221,11 @@ def main() -> None:
     stop_event = threading.Event()
     held_flag = threading.Event()
     buzzer_pin = None if args.no_buzzer else args.buzzer_pin
-    buzzer = ShutterBuzzer(buzzer_pin, active=args.buzzer_active)
+    buzzer = ShutterBuzzer(
+        buzzer_pin,
+        active=args.buzzer_active,
+        volume=args.buzzer_volume,
+    )
 
     try:
         from gpiozero import Button
@@ -328,7 +338,10 @@ def main() -> None:
     if buzzer.enabled:
         buzzer_kind = "active" if args.buzzer_active else "passive"
         LOGGER.info(
-            "Buzzer feedback on BCM GPIO %s (%s)", buzzer_pin, buzzer_kind
+            "Buzzer feedback on BCM GPIO %s (%s, volume=%.2f)",
+            buzzer_pin,
+            buzzer_kind,
+            args.buzzer_volume,
         )
     elif args.no_buzzer or buzzer_pin is None:
         LOGGER.info("Buzzer feedback disabled")

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -98,6 +98,24 @@ class ShutterBuzzerTest(unittest.TestCase):
         fake.on.assert_called_once_with()
         fake.off.assert_called_once_with()
 
+    def test_passive_tone_uses_soft_duty_cycle(self) -> None:
+        device = buzzer.ShutterBuzzer(None, volume=0.16)
+        fake = MagicMock()
+        device._device = fake
+        device._active = False
+
+        device._tone_on(1700.0)
+        self.assertEqual(fake.frequency, 1700.0)
+        self.assertEqual(fake.value, 0.16)
+
+        device._tone_off()
+        self.assertEqual(fake.value, 0)
+
+    def test_volume_is_clamped(self) -> None:
+        self.assertEqual(buzzer.clamp_volume(-1.0), 0.0)
+        self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
+        self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
+
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)
         fake = MagicMock()


### PR DESCRIPTION
## Summary
- Drive the passive buzzer with a soft PWM duty cycle (default `0.16`) instead of full-strength tones
- Shorten cue durations so sounds feel lighter
- Expose `TINY_FILM_BUZZER_VOLUME` / `--buzzer-volume` (and demo `--volume`) to tune loudness

## Test plan
- [ ] `sudo systemctl stop tiny-film-shutter.service`
- [ ] `python3 src/tiny-film-cam/buzzer.py --sound shutter` — quieter than before
- [ ] Try `--volume 0.10` if still loud, or `0.25` if too quiet
- [ ] Restart shutter service and tap for a photo
- [ ] `python3 -m unittest tests.test_buzzer -v`


Made with [Cursor](https://cursor.com)