### PR TITLE
Control buzzer loudness with burst density

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,9 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
-# Soft PWM duty cycle for passive buzzers (0.0–1.0). Raise toward 0.4 if too quiet.
-TINY_FILM_BUZZER_VOLUME=0.16
+# Soft loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
+# alone does nothing on transistor modules. Try 0.12 quiet / 0.4 louder.
+TINY_FILM_BUZZER_VOLUME=0.22
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -51,10 +51,13 @@ python3 src/tiny-film-cam/buzzer.py --sound beep
 Default pin is BCM 18. Override with `--pin` if needed. Use `--active` only if
 you wired a simple on/off active buzzer instead.
 
-Passive cues use a low PWM duty cycle so they stay soft. Try a quieter demo:
+Passive modules with a drive transistor ignore PWM duty cycle (they stay full
+loud while the pin is high). Loudness is controlled by bursting the tone
+on/off — lower `--volume` means shorter bursts. Compare:
 
 ```bash
 python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.12
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.5
 ```
 
 ## Using it with the shutter
@@ -88,7 +91,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.16` |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.22` (burst density) |
 
 ## Notes
 

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -7,8 +7,15 @@ import time
 
 LOGGER = logging.getLogger("tiny_film.buzzer")
 
-# Soft default PWM duty cycle for passive buzzers (0.0–1.0). Full 0.5 is loud.
-DEFAULT_VOLUME = 0.16
+# Soft default. Volume is burst density (0–1), not PWM duty — transistor
+# modules ignore duty cycle and stay full-loud whenever the pin is high.
+DEFAULT_VOLUME = 0.22
+
+# Chop the carrier this often; denser "on" slices sound louder.
+_BURST_PERIOD_SECONDS = 0.001
+
+# Carrier square-wave duty while a burst slice is active.
+_CARRIER_DUTY = 0.5
 
 # Passive module sweet spot is roughly 1.5–2.5 kHz.
 # Each pattern step is (frequency_hz, on_seconds, gap_seconds_after).
@@ -36,7 +43,9 @@ class ShutterBuzzer:
     Best-effort: if gpiozero is missing or the pin cannot be claimed, the
     buzzer disables itself so captures are never blocked by sound feedback.
 
-    Passive buzzers are driven with a low PWM duty cycle so cues stay soft.
+    Passive modules with a drive transistor stay full amplitude while the pin
+    is high, so loudness is controlled by bursting the tone on/off (volume =
+    fraction of time the carrier runs), not by PWM duty cycle.
     """
 
     def __init__(
@@ -61,7 +70,6 @@ class ShutterBuzzer:
             else:
                 from gpiozero import PWMOutputDevice
 
-                # Duty-cycle volume: keep value at 0 until a tone plays.
                 self._device = PWMOutputDevice(pin, frequency=1600, initial_value=0)
         except Exception:
             LOGGER.exception(
@@ -125,23 +133,61 @@ class ShutterBuzzer:
         with self._lock:
             try:
                 for frequency, on_seconds, gap_seconds in pattern:
-                    self._tone_on(frequency)
-                    time.sleep(on_seconds)
-                    self._tone_off()
+                    self._play_tone(frequency, on_seconds)
                     if gap_seconds:
                         time.sleep(gap_seconds)
             except Exception:
                 LOGGER.exception("Buzzer playback failed")
                 self._tone_off()
 
+    def _play_tone(self, frequency: float, on_seconds: float) -> None:
+        if self._device is None or on_seconds <= 0:
+            return
+        if self._active:
+            self._device.on()
+            time.sleep(on_seconds)
+            self._device.off()
+            return
+
+        if self._volume <= 0:
+            time.sleep(on_seconds)
+            return
+
+        self._device.frequency = max(1.0, frequency)
+        if self._volume >= 1.0:
+            self._device.value = _CARRIER_DUTY
+            time.sleep(on_seconds)
+            self._tone_off()
+            return
+
+        # Burst-gate the carrier so volume changes are audible on modules that
+        # only hard-switch VCC to the piezo (duty cycle alone does nothing).
+        on_slice = _BURST_PERIOD_SECONDS * self._volume
+        off_slice = _BURST_PERIOD_SECONDS - on_slice
+        deadline = time.monotonic() + on_seconds
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            self._device.value = _CARRIER_DUTY
+            time.sleep(min(on_slice, remaining))
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            self._tone_off()
+            if off_slice > 0:
+                time.sleep(min(off_slice, remaining))
+        self._tone_off()
+
     def _tone_on(self, frequency: float) -> None:
+        """Legacy helper used by tests; prefer `_play_tone` for playback."""
         if self._device is None:
             return
         if self._active:
             self._device.on()
         else:
             self._device.frequency = max(1.0, frequency)
-            self._device.value = self._volume
+            self._device.value = _CARRIER_DUTY
 
     def _tone_off(self) -> None:
         if self._device is None:
@@ -190,7 +236,10 @@ def parse_args() -> argparse.Namespace:
         "--volume",
         type=float,
         default=DEFAULT_VOLUME,
-        help=f"Passive PWM duty cycle 0.0–1.0 (default: {DEFAULT_VOLUME}).",
+        help=(
+            f"Passive loudness 0.0–1.0 via burst density "
+            f"(default: {DEFAULT_VOLUME})."
+        ),
     )
     parser.add_argument(
         "--sound",

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -110,8 +110,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--buzzer-volume",
         type=float,
-        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.16),
-        help="Passive buzzer PWM duty cycle 0.0–1.0 (default: 0.16, softer).",
+        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.22),
+        help="Passive buzzer loudness 0.0–1.0 via burst density (default: 0.22).",
     )
     parser.add_argument(
         "--hold-time",

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -24,6 +24,25 @@ def load_buzzer_module():
 buzzer = load_buzzer_module()
 
 
+class FakePwm:
+    def __init__(self) -> None:
+        self.frequency: float | None = None
+        self._value = 0.0
+        self.value_history: list[float] = []
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @value.setter
+    def value(self, next_value: float) -> None:
+        self._value = next_value
+        self.value_history.append(next_value)
+
+    def close(self) -> None:
+        return None
+
+
 class ShutterBuzzerTest(unittest.TestCase):
     def test_no_pin_disables_buzzer(self) -> None:
         device = buzzer.ShutterBuzzer(None)
@@ -73,19 +92,17 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertLess(pattern[0][1], 0.05)
         self.assertLess(pattern[1][1], 0.05)
 
-    def test_pattern_calls_tone_helpers_in_order(self) -> None:
+    def test_pattern_plays_tones_in_order(self) -> None:
         device = buzzer.ShutterBuzzer(None)
-        device._device = MagicMock()
-        device._tone_on = MagicMock()
-        device._tone_off = MagicMock()
+        device._device = FakePwm()
+        device._play_tone = MagicMock()
 
-        device._run_pattern(((2000.0, 0.0, 0.0), (1600.0, 0.0, 0.0)))
+        device._run_pattern(((2000.0, 0.01, 0.0), (1600.0, 0.01, 0.0)))
 
         self.assertEqual(
-            [call.args[0] for call in device._tone_on.call_args_list],
-            [2000.0, 1600.0],
+            [call.args for call in device._play_tone.call_args_list],
+            [(2000.0, 0.01), (1600.0, 0.01)],
         )
-        self.assertEqual(device._tone_off.call_count, 2)
 
     def test_active_pattern_toggles_device_on_and_off(self) -> None:
         device = buzzer.ShutterBuzzer(None)
@@ -93,28 +110,51 @@ class ShutterBuzzerTest(unittest.TestCase):
         device._device = fake
         device._active = True
 
-        device._run_pattern(((2000.0, 0.0, 0.0),))
+        device._play_tone(2000.0, 0.001)
 
         fake.on.assert_called_once_with()
         fake.off.assert_called_once_with()
 
-    def test_passive_tone_uses_soft_duty_cycle(self) -> None:
-        device = buzzer.ShutterBuzzer(None, volume=0.16)
-        fake = MagicMock()
+    def test_full_volume_uses_continuous_carrier(self) -> None:
+        device = buzzer.ShutterBuzzer(None, volume=1.0)
+        fake = FakePwm()
         device._device = fake
         device._active = False
 
-        device._tone_on(1700.0)
-        self.assertEqual(fake.frequency, 1700.0)
-        self.assertEqual(fake.value, 0.16)
+        device._play_tone(1700.0, 0.002)
 
-        device._tone_off()
-        self.assertEqual(fake.value, 0)
+        self.assertEqual(fake.frequency, 1700.0)
+        self.assertIn(buzzer._CARRIER_DUTY, fake.value_history)
+        self.assertEqual(fake.value, 0.0)
+
+    def test_partial_volume_bursts_carrier(self) -> None:
+        device = buzzer.ShutterBuzzer(None, volume=0.25)
+        fake = FakePwm()
+        device._device = fake
+        device._active = False
+
+        device._play_tone(1700.0, 0.004)
+
+        self.assertEqual(fake.frequency, 1700.0)
+        self.assertGreater(fake.value_history.count(buzzer._CARRIER_DUTY), 1)
+        self.assertGreater(fake.value_history.count(0.0), 1)
+        self.assertEqual(fake.value, 0.0)
+
+    def test_zero_volume_stays_silent(self) -> None:
+        device = buzzer.ShutterBuzzer(None, volume=0.0)
+        fake = FakePwm()
+        device._device = fake
+        device._active = False
+
+        device._play_tone(1700.0, 0.002)
+
+        self.assertIsNone(fake.frequency)
+        self.assertEqual(fake.value_history, [])
 
     def test_volume_is_clamped(self) -> None:
         self.assertEqual(buzzer.clamp_volume(-1.0), 0.0)
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
-        self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
+        self.assertEqual(buzzer.clamp_volume(0.22), 0.22)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary
- PWM duty-cycle volume did nothing on the transistor-driven passive module (pin high = full loud)
- Loudness is now burst density: the carrier square wave is chopped on/off; lower volume = shorter bursts
- Default volume `0.22`; compare `--volume 0.12` vs `0.5` in the demo CLI

## Test plan
- [ ] `sudo systemctl stop tiny-film-shutter.service`
- [ ] `python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.12`
- [ ] `python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.5` — clearly louder than 0.12
- [ ] Restart shutter service; tap photo at default volume
- [ ] `python3 -m unittest tests.test_buzzer -v`


Made with [Cursor](https://cursor.com)