### PR TITLE
Tune buzzer cues for a calmer, softer feel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,9 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
-# Soft loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. Try 0.12 quiet / 0.4 louder.
-TINY_FILM_BUZZER_VOLUME=0.22
+# Calm loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
+# alone does nothing on transistor modules. Try 0.10 quieter / 0.3 louder.
+TINY_FILM_BUZZER_VOLUME=0.14
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -56,9 +56,11 @@ loud while the pin is high). Loudness is controlled by bursting the tone
 on/off — lower `--volume` means shorter bursts. Compare:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.12
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.5
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.10
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.3
 ```
+
+Cues are tuned low and soft by default (around 1.5 kHz) so they stay calm.
 
 ## Using it with the shutter
 
@@ -91,7 +93,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.22` (burst density) |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.14` (burst density) |
 
 ## Notes
 

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -7,9 +7,9 @@ import time
 
 LOGGER = logging.getLogger("tiny_film.buzzer")
 
-# Soft default. Volume is burst density (0–1), not PWM duty — transistor
+# Calm default. Volume is burst density (0–1), not PWM duty — transistor
 # modules ignore duty cycle and stay full-loud whenever the pin is high.
-DEFAULT_VOLUME = 0.22
+DEFAULT_VOLUME = 0.14
 
 # Chop the carrier this often; denser "on" slices sound louder.
 _BURST_PERIOD_SECONDS = 0.001
@@ -17,17 +17,19 @@ _BURST_PERIOD_SECONDS = 0.001
 # Carrier square-wave duty while a burst slice is active.
 _CARRIER_DUTY = 0.5
 
-# Passive module sweet spot is roughly 1.5–2.5 kHz.
-# Each pattern step is (frequency_hz, on_seconds, gap_seconds_after).
+# Keep cues near the low end of the module band (~1.5 kHz) so they stay
+# soft instead of piercing. Each step: (frequency_hz, on_seconds, gap_after).
 # Frequency is ignored for active buzzers (simple on/off).
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
-    # Soft open/close click-clack — short and quiet.
-    "shutter": ((1750.0, 0.014, 0.018), (1500.0, 0.022, 0.0)),
-    "click": ((1550.0, 0.035, 0.0),),
-    "beep": ((1600.0, 0.07, 0.0),),
-    "chirp": ((1700.0, 0.05, 0.0),),
-    "alert": ((1800.0, 0.10, 0.0),),
-    "double": ((1500.0, 0.04, 0.04), (1500.0, 0.04, 0.0)),
+    # Soft descending settle — calm shutter cue, not a sharp slap.
+    "shutter": ((1580.0, 0.03, 0.045), (1500.0, 0.05, 0.0)),
+    "click": ((1520.0, 0.04, 0.0),),
+    "beep": ((1540.0, 0.09, 0.0),),
+    # Gentle two-step for video start.
+    "chirp": ((1560.0, 0.05, 0.035), (1500.0, 0.07, 0.0)),
+    # Soft double pulse — noticeable, not alarming.
+    "alert": ((1500.0, 0.08, 0.07), (1500.0, 0.08, 0.0)),
+    "double": ((1520.0, 0.05, 0.055), (1500.0, 0.06, 0.0)),
 }
 
 SOUND_ORDER = ("shutter", "click", "beep", "chirp", "alert", "double")

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -110,8 +110,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--buzzer-volume",
         type=float,
-        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.22),
-        help="Passive buzzer loudness 0.0–1.0 via burst density (default: 0.22).",
+        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.14),
+        help="Passive buzzer loudness 0.0–1.0 via burst density (default: 0.14).",
     )
     parser.add_argument(
         "--hold-time",

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -85,12 +85,13 @@ class ShutterBuzzerTest(unittest.TestCase):
         for name in buzzer.SOUND_ORDER:
             self.assertIn(name, buzzer.SOUNDS)
 
-    def test_shutter_pattern_is_two_step_click_clack(self) -> None:
+    def test_shutter_pattern_is_soft_descending_pair(self) -> None:
         pattern = buzzer.SOUNDS["shutter"]
         self.assertEqual(len(pattern), 2)
         self.assertGreater(pattern[0][0], pattern[1][0])
-        self.assertLess(pattern[0][1], 0.05)
-        self.assertLess(pattern[1][1], 0.05)
+        self.assertLessEqual(pattern[0][1], 0.06)
+        self.assertLessEqual(pattern[1][1], 0.06)
+        self.assertLessEqual(pattern[0][0], 1650.0)
 
     def test_pattern_plays_tones_in_order(self) -> None:
         device = buzzer.ShutterBuzzer(None)
@@ -154,7 +155,10 @@ class ShutterBuzzerTest(unittest.TestCase):
     def test_volume_is_clamped(self) -> None:
         self.assertEqual(buzzer.clamp_volume(-1.0), 0.0)
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
-        self.assertEqual(buzzer.clamp_volume(0.22), 0.22)
+        self.assertEqual(buzzer.clamp_volume(0.14), 0.14)
+
+    def test_default_volume_is_calm(self) -> None:
+        self.assertLessEqual(buzzer.DEFAULT_VOLUME, 0.2)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary
- Retune all cues to the low end of the module band (~1.5 kHz) so they are less piercing
- Make the shutter a soft descending settle instead of a sharp click-clack
- Lower default volume to `0.14` for a calmer everyday feel

## Test plan
- [ ] `sudo systemctl stop tiny-film-shutter.service`
- [ ] `python3 src/tiny-film-cam/buzzer.py --sound shutter` — soft, calm, not sharp
- [ ] `python3 src/tiny-film-cam/buzzer.py` — full set feels gentle
- [ ] Restart shutter service and tap photo / hold for video
- [ ] Raise `TINY_FILM_BUZZER_VOLUME` slightly if too quiet


Made with [Cursor](https://cursor.com)