### PR TITLE
Restore original buzzer cues with burst volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,9 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
-# Calm loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. Try 0.10 quieter / 0.3 louder.
-TINY_FILM_BUZZER_VOLUME=0.14
+# Loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
+# alone does nothing on transistor modules. Try 0.12 quieter / 0.4 louder.
+TINY_FILM_BUZZER_VOLUME=0.22
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,11 +5,11 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **shutter** | Photo capture (open/close click-clack) |
+| **click** | Shutter button fires (photo or video) |
+| **beep** | Photo saved |
 | **chirp** | Video recording started |
 | **double** | Video saved |
 | **alert** | Capture or recording failed |
-| **click** / **beep** | Extra cues in the hardware demo |
 
 By default the shutter daemon uses a **passive** buzzer on **BCM GPIO 18**.
 Leave `TINY_FILM_BUZZER_PIN` blank in `.env`, or pass `--no-buzzer`, to disable.
@@ -56,11 +56,9 @@ loud while the pin is high). Loudness is controlled by bursting the tone
 on/off — lower `--volume` means shorter bursts. Compare:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.10
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.3
+python3 src/tiny-film-cam/buzzer.py --sound beep --volume 0.12
+python3 src/tiny-film-cam/buzzer.py --sound beep --volume 0.5
 ```
-
-Cues are tuned low and soft by default (around 1.5 kHz) so they stay calm.
 
 ## Using it with the shutter
 
@@ -93,7 +91,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.14` (burst density) |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.22` (burst density) |
 
 ## Notes
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -61,9 +61,9 @@ scp -r suveen@172.20.10.2:/home/suveen/tiny-film/data/captures .
 python3 src/tiny-film-cam/buzzer.py
 ```
 
-## Play the camera shutter sound
+## Play one buzzer sound
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound shutter
+python3 src/tiny-film-cam/buzzer.py --sound beep
 ```
 
 ## Install boot services

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -7,9 +7,9 @@ import time
 
 LOGGER = logging.getLogger("tiny_film.buzzer")
 
-# Calm default. Volume is burst density (0–1), not PWM duty — transistor
-# modules ignore duty cycle and stay full-loud whenever the pin is high.
-DEFAULT_VOLUME = 0.14
+# Volume is burst density (0–1), not PWM duty — transistor modules ignore
+# duty cycle and stay full-loud whenever the pin is high.
+DEFAULT_VOLUME = 0.22
 
 # Chop the carrier this often; denser "on" slices sound louder.
 _BURST_PERIOD_SECONDS = 0.001
@@ -17,22 +17,18 @@ _BURST_PERIOD_SECONDS = 0.001
 # Carrier square-wave duty while a burst slice is active.
 _CARRIER_DUTY = 0.5
 
-# Keep cues near the low end of the module band (~1.5 kHz) so they stay
-# soft instead of piercing. Each step: (frequency_hz, on_seconds, gap_after).
+# Original cue set (module sweet spot ~1.5–2.5 kHz).
+# Each step: (frequency_hz, on_seconds, gap_seconds_after).
 # Frequency is ignored for active buzzers (simple on/off).
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
-    # Soft descending settle — calm shutter cue, not a sharp slap.
-    "shutter": ((1580.0, 0.03, 0.045), (1500.0, 0.05, 0.0)),
-    "click": ((1520.0, 0.04, 0.0),),
-    "beep": ((1540.0, 0.09, 0.0),),
-    # Gentle two-step for video start.
-    "chirp": ((1560.0, 0.05, 0.035), (1500.0, 0.07, 0.0)),
-    # Soft double pulse — noticeable, not alarming.
-    "alert": ((1500.0, 0.08, 0.07), (1500.0, 0.08, 0.0)),
-    "double": ((1520.0, 0.05, 0.055), (1500.0, 0.06, 0.0)),
+    "click": ((1800.0, 0.06, 0.0),),
+    "beep": ((2000.0, 0.15, 0.0),),
+    "chirp": ((2200.0, 0.10, 0.0),),
+    "alert": ((2400.0, 0.25, 0.0),),
+    "double": ((1600.0, 0.08, 0.05), (1600.0, 0.08, 0.0)),
 }
 
-SOUND_ORDER = ("shutter", "click", "beep", "chirp", "alert", "double")
+SOUND_ORDER = ("click", "beep", "chirp", "alert", "double")
 
 
 def clamp_volume(volume: float) -> float:
@@ -84,17 +80,13 @@ class ShutterBuzzer:
     def enabled(self) -> bool:
         return self._device is not None
 
-    def shutter(self) -> None:
-        """Mechanical shutter-like click-clack for a photo capture."""
-        self.play("shutter")
-
     def click(self) -> None:
         """Short tick when the shutter button fires."""
         self.play("click")
 
     def photo_ok(self) -> None:
         """Confirmation that a photo was saved."""
-        self.play("shutter")
+        self.play("beep")
 
     def video_start(self) -> None:
         """Cue that video recording has started."""

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -110,8 +110,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--buzzer-volume",
         type=float,
-        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.14),
-        help="Passive buzzer loudness 0.0–1.0 via burst density (default: 0.14).",
+        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.22),
+        help="Passive buzzer loudness 0.0–1.0 via burst density (default: 0.22).",
     )
     parser.add_argument(
         "--hold-time",
@@ -246,7 +246,7 @@ def main() -> None:
 
         try:
             LOGGER.info("Button pressed; capturing photo")
-            buzzer.shutter()
+            buzzer.click()
             settings = CaptureSettings(
                 output_dir=output_dir,
                 width=args.width,
@@ -267,6 +267,7 @@ def main() -> None:
             )
             output_paths = capture_photos(settings)
             LOGGER.info("Saved %s photo(s): %s", len(output_paths), output_paths)
+            buzzer.photo_ok()
         except Exception:
             LOGGER.exception("Capture failed")
             buzzer.error()
@@ -281,6 +282,7 @@ def main() -> None:
 
         try:
             LOGGER.info("Button held; recording %.1fs video", args.video_duration)
+            buzzer.click()
             buzzer.video_start()
             settings = VideoSettings(
                 output_dir=output_dir,

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -48,7 +48,6 @@ class ShutterBuzzerTest(unittest.TestCase):
         device = buzzer.ShutterBuzzer(None)
 
         self.assertFalse(device.enabled)
-        device.shutter()
         device.click()
         device.photo_ok()
         device.video_start()
@@ -80,18 +79,17 @@ class ShutterBuzzerTest(unittest.TestCase):
     def test_named_sounds_exist(self) -> None:
         self.assertEqual(
             tuple(buzzer.SOUND_ORDER),
-            ("shutter", "click", "beep", "chirp", "alert", "double"),
+            ("click", "beep", "chirp", "alert", "double"),
         )
         for name in buzzer.SOUND_ORDER:
             self.assertIn(name, buzzer.SOUNDS)
 
-    def test_shutter_pattern_is_soft_descending_pair(self) -> None:
-        pattern = buzzer.SOUNDS["shutter"]
-        self.assertEqual(len(pattern), 2)
-        self.assertGreater(pattern[0][0], pattern[1][0])
-        self.assertLessEqual(pattern[0][1], 0.06)
-        self.assertLessEqual(pattern[1][1], 0.06)
-        self.assertLessEqual(pattern[0][0], 1650.0)
+    def test_original_cue_frequencies(self) -> None:
+        self.assertEqual(buzzer.SOUNDS["click"][0][0], 1800.0)
+        self.assertEqual(buzzer.SOUNDS["beep"][0][0], 2000.0)
+        self.assertEqual(buzzer.SOUNDS["chirp"][0][0], 2200.0)
+        self.assertEqual(buzzer.SOUNDS["alert"][0][0], 2400.0)
+        self.assertEqual(buzzer.SOUNDS["double"][0][0], 1600.0)
 
     def test_pattern_plays_tones_in_order(self) -> None:
         device = buzzer.ShutterBuzzer(None)
@@ -155,10 +153,7 @@ class ShutterBuzzerTest(unittest.TestCase):
     def test_volume_is_clamped(self) -> None:
         self.assertEqual(buzzer.clamp_volume(-1.0), 0.0)
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
-        self.assertEqual(buzzer.clamp_volume(0.14), 0.14)
-
-    def test_default_volume_is_calm(self) -> None:
-        self.assertLessEqual(buzzer.DEFAULT_VOLUME, 0.2)
+        self.assertEqual(buzzer.clamp_volume(0.22), 0.22)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary
- Restore the original five cues (click 1800, beep 2000, chirp 2200, alert 2400, double 1600)
- Keep burst-density volume control (`TINY_FILM_BUZZER_VOLUME`, default `0.22`)
- Photo path is click + beep again; video is click + chirp / double

## Test plan
- [ ] `sudo systemctl stop tiny-film-shutter.service`
- [ ] `python3 src/tiny-film-cam/buzzer.py` — original five tones
- [ ] Compare `--volume 0.12` vs `0.5` on `--sound beep`
- [ ] Restart shutter; tap photo (click then beep), hold for video (chirp / double)


Made with [Cursor](https://cursor.com)