### PR TITLE
Add pleasant configurable photo cues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,11 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
+# Photo cue: gentle (default), shutter, sparkle, or minimal.
+TINY_FILM_BUZZER_PHOTO_SOUND=gentle
 # Loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. Try 0.12 quieter / 0.4 louder.
-TINY_FILM_BUZZER_VOLUME=0.22
+# alone does nothing on transistor modules. Try 0.10 quieter / 0.3 louder.
+TINY_FILM_BUZZER_VOLUME=0.16
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,8 +5,11 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **click** | Shutter button fires (photo or video) |
-| **beep** | Photo saved |
+| **click** | A very short acknowledgement when the button fires |
+| **gentle** | Photo saved (default; a soft descending two-note cue) |
+| **shutter** | Photo saved option with three dry mechanical-style taps |
+| **sparkle** | Photo saved option with a quick ascending major chord |
+| **minimal** | Photo saved option with one low tick |
 | **chirp** | Video recording started |
 | **double** | Video saved |
 | **alert** | Capture or recording failed |
@@ -42,11 +45,16 @@ With the module wired, run the demo from the project root on the Pi:
 python3 src/tiny-film-cam/buzzer.py
 ```
 
-Or play one sound:
+Or audition the four photo sounds individually:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound beep
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.16
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.16
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 0.16
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.16
 ```
+
+The old `--sound beep` name remains as an alias for `gentle`.
 
 Default pin is BCM 18. Override with `--pin` if needed. Use `--active` only if
 you wired a simple on/off active buzzer instead.
@@ -56,8 +64,8 @@ loud while the pin is high). Loudness is controlled by bursting the tone
 on/off — lower `--volume` means shorter bursts. Compare:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound beep --volume 0.12
-python3 src/tiny-film-cam/buzzer.py --sound beep --volume 0.5
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.10
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 ```
 
 ## Using it with the shutter
@@ -91,7 +99,8 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.22` (burst density) |
+| Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `gentle` |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.16` (burst density) |
 
 ## Notes
 
@@ -101,3 +110,6 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
   confirmation and run in a separate process.
 - Tones play on a background thread, so they never delay the next capture.
 - Stay near **1.5–2.5 kHz** for this module; that is its claimed tone range.
+- A passive piezo can only make simple square-wave tones, not play sampled
+  camera audio. The presets use short timing and musical intervals to make the
+  most of that hardware.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,7 +63,7 @@ python3 src/tiny-film-cam/buzzer.py
 
 ## Play one buzzer sound
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound beep
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.16
 ```
 
 ## Install boot services

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -8,8 +8,10 @@ import time
 LOGGER = logging.getLogger("tiny_film.buzzer")
 
 # Volume is burst density (0–1), not PWM duty — transistor modules ignore
-# duty cycle and stay full-loud whenever the pin is high.
-DEFAULT_VOLUME = 0.22
+# duty cycle and stay full-loud whenever the pin is high. A restrained default
+# keeps the little piezo from dominating the moment.
+DEFAULT_VOLUME = 0.16
+DEFAULT_PHOTO_SOUND = "gentle"
 
 # Chop the carrier this often; denser "on" slices sound louder.
 _BURST_PERIOD_SECONDS = 0.001
@@ -17,18 +19,47 @@ _BURST_PERIOD_SECONDS = 0.001
 # Carrier square-wave duty while a burst slice is active.
 _CARRIER_DUTY = 0.5
 
-# Original cue set (module sweet spot ~1.5–2.5 kHz).
+# Musical pitches are rounded to the nearest hertz and kept inside the
+# module's useful ~1.5–2.5 kHz band. Short consonant intervals sound less like
+# an appliance alarm than a long single-frequency beep.
+#
 # Each step: (frequency_hz, on_seconds, gap_seconds_after).
 # Frequency is ignored for active buzzers (simple on/off).
+_G6 = 1568.0
+_B6 = 1976.0
+_D7 = 2349.0
+
+PHOTO_SOUNDS = ("gentle", "shutter", "sparkle", "minimal")
+
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
-    "click": ((1800.0, 0.06, 0.0),),
-    "beep": ((2000.0, 0.15, 0.0),),
-    "chirp": ((2200.0, 0.10, 0.0),),
-    "alert": ((2400.0, 0.25, 0.0),),
-    "double": ((1600.0, 0.08, 0.05), (1600.0, 0.08, 0.0)),
+    # A short, resolving major-third fall. This is the default photo cue.
+    "gentle": ((_B6, 0.022, 0.014), (_G6, 0.040, 0.0)),
+    # Dry high/low taps that suggest a mechanical shutter rather than a beep.
+    "shutter": (
+        (2200.0, 0.010, 0.008),
+        (1800.0, 0.014, 0.009),
+        (_G6, 0.022, 0.0),
+    ),
+    # A quick G-major arpeggio for a brighter, playful confirmation.
+    "sparkle": (
+        (_G6, 0.020, 0.012),
+        (_B6, 0.022, 0.012),
+        (_D7, 0.032, 0.0),
+    ),
+    # The least intrusive option: one low, very short tick.
+    "minimal": ((_G6, 0.030, 0.0),),
+    # Semantic cues used elsewhere in the shutter daemon.
+    "click": ((_G6, 0.018, 0.0),),
+    "chirp": ((_G6, 0.035, 0.020), (_B6, 0.050, 0.0)),
+    "double": ((_B6, 0.035, 0.045), (_G6, 0.045, 0.0)),
+    "alert": ((_G6, 0.070, 0.055), (_G6, 0.070, 0.0)),
 }
 
-SOUND_ORDER = ("click", "beep", "chirp", "alert", "double")
+# Keep the old CLI name working, but make it the new gentle cue.
+SOUNDS["beep"] = SOUNDS["gentle"]
+
+# The no-argument hardware demo focuses on distinct sounds, not aliases.
+SOUND_ORDER = PHOTO_SOUNDS + ("chirp", "double", "alert")
 
 
 def clamp_volume(volume: float) -> float:
@@ -51,9 +82,16 @@ class ShutterBuzzer:
         pin: int | None,
         active: bool = False,
         volume: float = DEFAULT_VOLUME,
+        photo_sound: str = DEFAULT_PHOTO_SOUND,
     ) -> None:
+        if photo_sound not in PHOTO_SOUNDS:
+            choices = ", ".join(PHOTO_SOUNDS)
+            raise ValueError(
+                f"Unknown photo sound: {photo_sound!r}; choose one of: {choices}"
+            )
         self._active = active
         self._volume = clamp_volume(volume)
+        self._photo_sound = photo_sound
         self._device = None
         self._lock = threading.Lock()
 
@@ -86,7 +124,7 @@ class ShutterBuzzer:
 
     def photo_ok(self) -> None:
         """Confirmation that a photo was saved."""
-        self.play("beep")
+        self.play(self._photo_sound)
 
     def video_start(self) -> None:
         """Cue that video recording has started."""
@@ -237,7 +275,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--sound",
-        choices=SOUND_ORDER,
+        choices=tuple(SOUNDS),
         help="Play a single named sound instead of the full demo.",
     )
     return parser.parse_args()

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -7,7 +7,12 @@ import signal
 import threading
 from pathlib import Path
 
-from buzzer import ShutterBuzzer
+from buzzer import (
+    DEFAULT_PHOTO_SOUND,
+    DEFAULT_VOLUME,
+    PHOTO_SOUNDS,
+    ShutterBuzzer,
+)
 from camera import (
     AWB_MODES,
     CaptureSettings,
@@ -110,8 +115,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--buzzer-volume",
         type=float,
-        default=env_float("TINY_FILM_BUZZER_VOLUME", 0.22),
-        help="Passive buzzer loudness 0.0–1.0 via burst density (default: 0.22).",
+        default=env_float("TINY_FILM_BUZZER_VOLUME", DEFAULT_VOLUME),
+        help=(
+            "Passive buzzer loudness 0.0–1.0 via burst density "
+            f"(default: {DEFAULT_VOLUME})."
+        ),
+    )
+    parser.add_argument(
+        "--buzzer-photo-sound",
+        choices=PHOTO_SOUNDS,
+        default=os.environ.get(
+            "TINY_FILM_BUZZER_PHOTO_SOUND", DEFAULT_PHOTO_SOUND
+        ),
+        help=(
+            "Photo-saved cue: gentle, shutter, sparkle, or minimal "
+            f"(default: {DEFAULT_PHOTO_SOUND})."
+        ),
     )
     parser.add_argument(
         "--hold-time",
@@ -225,6 +244,7 @@ def main() -> None:
         buzzer_pin,
         active=args.buzzer_active,
         volume=args.buzzer_volume,
+        photo_sound=args.buzzer_photo_sound,
     )
 
     try:
@@ -340,10 +360,11 @@ def main() -> None:
     if buzzer.enabled:
         buzzer_kind = "active" if args.buzzer_active else "passive"
         LOGGER.info(
-            "Buzzer feedback on BCM GPIO %s (%s, volume=%.2f)",
+            "Buzzer feedback on BCM GPIO %s (%s, volume=%.2f, photo=%s)",
             buzzer_pin,
             buzzer_kind,
             args.buzzer_volume,
+            args.buzzer_photo_sound,
         )
     elif args.no_buzzer or buzzer_pin is None:
         LOGGER.info("Buzzer feedback disabled")

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -79,17 +79,45 @@ class ShutterBuzzerTest(unittest.TestCase):
     def test_named_sounds_exist(self) -> None:
         self.assertEqual(
             tuple(buzzer.SOUND_ORDER),
-            ("click", "beep", "chirp", "alert", "double"),
+            (
+                "gentle",
+                "shutter",
+                "sparkle",
+                "minimal",
+                "chirp",
+                "double",
+                "alert",
+            ),
         )
         for name in buzzer.SOUND_ORDER:
             self.assertIn(name, buzzer.SOUNDS)
+        self.assertIs(buzzer.SOUNDS["beep"], buzzer.SOUNDS["gentle"])
 
-    def test_original_cue_frequencies(self) -> None:
-        self.assertEqual(buzzer.SOUNDS["click"][0][0], 1800.0)
-        self.assertEqual(buzzer.SOUNDS["beep"][0][0], 2000.0)
-        self.assertEqual(buzzer.SOUNDS["chirp"][0][0], 2200.0)
-        self.assertEqual(buzzer.SOUNDS["alert"][0][0], 2400.0)
-        self.assertEqual(buzzer.SOUNDS["double"][0][0], 1600.0)
+    def test_gentle_cue_is_short_descending_major_third(self) -> None:
+        pattern = buzzer.SOUNDS["gentle"]
+
+        self.assertEqual(len(pattern), 2)
+        self.assertGreater(pattern[0][0], pattern[1][0])
+        self.assertAlmostEqual(pattern[0][0] / pattern[1][0], 1.25, delta=0.02)
+        self.assertLess(sum(step[1] + step[2] for step in pattern), 0.1)
+
+    def test_each_photo_sound_stays_in_module_range_and_under_150ms(self) -> None:
+        for name in buzzer.PHOTO_SOUNDS:
+            pattern = buzzer.SOUNDS[name]
+            self.assertTrue(all(1500.0 <= step[0] <= 2500.0 for step in pattern))
+            self.assertLess(sum(step[1] + step[2] for step in pattern), 0.15)
+
+    def test_photo_ok_uses_selected_sound(self) -> None:
+        device = buzzer.ShutterBuzzer(None, photo_sound="sparkle")
+        device.play = MagicMock()
+
+        device.photo_ok()
+
+        device.play.assert_called_once_with("sparkle")
+
+    def test_unknown_photo_sound_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown photo sound"):
+            buzzer.ShutterBuzzer(None, photo_sound="siren")
 
     def test_pattern_plays_tones_in_order(self) -> None:
         device = buzzer.ShutterBuzzer(None)
@@ -153,7 +181,10 @@ class ShutterBuzzerTest(unittest.TestCase):
     def test_volume_is_clamped(self) -> None:
         self.assertEqual(buzzer.clamp_volume(-1.0), 0.0)
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
-        self.assertEqual(buzzer.clamp_volume(0.22), 0.22)
+        self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
+
+    def test_default_volume_is_restrained(self) -> None:
+        self.assertLessEqual(buzzer.DEFAULT_VOLUME, 0.2)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary

- add four passive-buzzer photo presets: gentle, shutter, sparkle, and minimal
- make each preset deliberately distinct in both pitch and rhythm
- make the gentle descending cue the default and lower default burst volume to 0.16
- allow the photo cue to be selected with `--buzzer-photo-sound` or `TINY_FILM_BUZZER_PHOTO_SOUND`
- add a sustained 1.5 kHz / 2.5 kHz `pitch-test` that identifies fixed-pitch active buzzer modules
- keep `beep` as a backwards-compatible alias and document hardware audition commands

## Why

The previous photo feedback used long, isolated high-frequency tones, which sounded harsh during repeated captures.

The first version of this PR made the tone patterns too short and retained the existing 1 ms volume gate. At the default 0.16 volume, that gate enabled the carrier for just 0.16 ms—less than one cycle of a 1.5 kHz note. The volume gate therefore masked the intended pitches and made the presets sound nearly identical.

Playback now uses a slower gate and guarantees at least three complete carrier cycles in every active slice. The cues are also longer and have clearly different pulse counts, so active fixed-pitch modules can still distinguish them by rhythm.

## User impact

Users can audition four meaningfully different photo cues, select one through the daemon CLI or environment, and determine whether their hardware supports variable pitch with:

```bash
python3 src/tiny-film-cam/buzzer.py --sound pitch-test --volume 1.0
```

## Validation

- `python3 -m unittest discover -s tests -v` (31 tests passed)
- `python3 src/tiny-film-cam/buzzer.py --help`
- `python3 src/tiny-film-cam/shutter_daemon.py --help`
- `git diff --check`
