### PR TITLE
Make buzzer cues audibly distinct

### DIFF
--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -56,6 +56,18 @@ python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.16
 
 The old `--sound beep` name remains as an alias for `gentle`.
 
+If those four still appear to have the same pitch, run the diagnostic at full
+volume:
+
+```bash
+python3 src/tiny-film-cam/buzzer.py --sound pitch-test --volume 1.0
+```
+
+It plays a long 1.5 kHz tone followed by a long 2.5 kHz tone. A passive buzzer
+will produce two unmistakably different pitches. If both pitches sound the
+same, the connected module is an **active buzzer** with its own fixed-frequency
+oscillator; software can vary only its pulse rhythm, not its pitch.
+
 Default pin is BCM 18. Override with `--pin` if needed. Use `--active` only if
 you wired a simple on/off active buzzer instead.
 
@@ -113,3 +125,5 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 - A passive piezo can only make simple square-wave tones, not play sampled
   camera audio. The presets use short timing and musical intervals to make the
   most of that hardware.
+- Burst volume gating retains at least three complete carrier cycles per pulse
+  so low-volume playback does not mask the selected pitch.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -66,6 +66,11 @@ python3 src/tiny-film-cam/buzzer.py
 python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.16
 ```
 
+## Check whether the buzzer can change pitch
+```bash
+python3 src/tiny-film-cam/buzzer.py --sound pitch-test --volume 1.0
+```
+
 ## Install boot services
 ```bash
 ./scripts/install_service.sh --enable-now

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -13,8 +13,12 @@ LOGGER = logging.getLogger("tiny_film.buzzer")
 DEFAULT_VOLUME = 0.16
 DEFAULT_PHOTO_SOUND = "gentle"
 
-# Chop the carrier this often; denser "on" slices sound louder.
-_BURST_PERIOD_SECONDS = 0.001
+# Gate the carrier slowly enough that every "on" slice contains several
+# complete tone cycles. The old 1 ms gate produced 0.16 ms slices at the
+# default volume — shorter than one cycle of a 1.5 kHz note — so the gate
+# itself dominated and made different pitches sound almost identical.
+_BURST_PERIOD_SECONDS = 0.010
+_MIN_CARRIER_CYCLES_PER_BURST = 3.0
 
 # Carrier square-wave duty while a burst slice is active.
 _CARRIER_DUTY = 0.5
@@ -32,27 +36,28 @@ _D7 = 2349.0
 PHOTO_SOUNDS = ("gentle", "shutter", "sparkle", "minimal")
 
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
-    # A short, resolving major-third fall. This is the default photo cue.
-    "gentle": ((_B6, 0.022, 0.014), (_G6, 0.040, 0.0)),
+    # A clearly audible, resolving major-third fall. This is the default cue.
+    "gentle": ((_B6, 0.090, 0.035), (_G6, 0.130, 0.0)),
     # Dry high/low taps that suggest a mechanical shutter rather than a beep.
     "shutter": (
-        (2200.0, 0.010, 0.008),
-        (1800.0, 0.014, 0.009),
-        (_G6, 0.022, 0.0),
+        (2400.0, 0.020, 0.018),
+        (1750.0, 0.035, 0.0),
     ),
     # A quick G-major arpeggio for a brighter, playful confirmation.
     "sparkle": (
-        (_G6, 0.020, 0.012),
-        (_B6, 0.022, 0.012),
-        (_D7, 0.032, 0.0),
+        (_G6, 0.065, 0.025),
+        (_B6, 0.065, 0.025),
+        (_D7, 0.110, 0.0),
     ),
     # The least intrusive option: one low, very short tick.
-    "minimal": ((_G6, 0.030, 0.0),),
+    "minimal": ((_G6, 0.045, 0.0),),
     # Semantic cues used elsewhere in the shutter daemon.
-    "click": ((_G6, 0.018, 0.0),),
-    "chirp": ((_G6, 0.035, 0.020), (_B6, 0.050, 0.0)),
-    "double": ((_B6, 0.035, 0.045), (_G6, 0.045, 0.0)),
-    "alert": ((_G6, 0.070, 0.055), (_G6, 0.070, 0.0)),
+    "click": ((_G6, 0.025, 0.0),),
+    "chirp": ((_G6, 0.080, 0.030), (_B6, 0.130, 0.0)),
+    "double": ((_B6, 0.070, 0.060), (_G6, 0.100, 0.0)),
+    "alert": ((_G6, 0.130, 0.090), (_G6, 0.130, 0.0)),
+    # Deliberately long extremes for identifying passive versus active modules.
+    "pitch-test": ((1500.0, 0.400, 0.180), (2500.0, 0.400, 0.0)),
 }
 
 # Keep the old CLI name working, but make it the new gentle cue.
@@ -64,6 +69,17 @@ SOUND_ORDER = PHOTO_SOUNDS + ("chirp", "double", "alert")
 
 def clamp_volume(volume: float) -> float:
     return max(0.0, min(1.0, volume))
+
+
+def _burst_slices(frequency: float, volume: float) -> tuple[float, float]:
+    """Return carrier-on/off times that preserve the requested pitch."""
+    safe_frequency = max(1.0, frequency)
+    burst_period = max(
+        _BURST_PERIOD_SECONDS,
+        _MIN_CARRIER_CYCLES_PER_BURST / safe_frequency / volume,
+    )
+    on_slice = burst_period * volume
+    return on_slice, burst_period - on_slice
 
 
 class ShutterBuzzer:
@@ -194,8 +210,8 @@ class ShutterBuzzer:
 
         # Burst-gate the carrier so volume changes are audible on modules that
         # only hard-switch VCC to the piezo (duty cycle alone does nothing).
-        on_slice = _BURST_PERIOD_SECONDS * self._volume
-        off_slice = _BURST_PERIOD_SECONDS - on_slice
+        # Each slice includes enough complete cycles to retain the tone.
+        on_slice, off_slice = _burst_slices(frequency, self._volume)
         deadline = time.monotonic() + on_seconds
         while True:
             remaining = deadline - time.monotonic()

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -99,13 +99,19 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertEqual(len(pattern), 2)
         self.assertGreater(pattern[0][0], pattern[1][0])
         self.assertAlmostEqual(pattern[0][0] / pattern[1][0], 1.25, delta=0.02)
-        self.assertLess(sum(step[1] + step[2] for step in pattern), 0.1)
+        self.assertLess(sum(step[1] + step[2] for step in pattern), 0.3)
 
-    def test_each_photo_sound_stays_in_module_range_and_under_150ms(self) -> None:
+    def test_each_photo_sound_stays_in_module_range_and_under_400ms(self) -> None:
         for name in buzzer.PHOTO_SOUNDS:
             pattern = buzzer.SOUNDS[name]
             self.assertTrue(all(1500.0 <= step[0] <= 2500.0 for step in pattern))
-            self.assertLess(sum(step[1] + step[2] for step in pattern), 0.15)
+            self.assertLess(sum(step[1] + step[2] for step in pattern), 0.4)
+
+    def test_pitch_test_uses_long_frequency_extremes(self) -> None:
+        pattern = buzzer.SOUNDS["pitch-test"]
+
+        self.assertEqual([step[0] for step in pattern], [1500.0, 2500.0])
+        self.assertTrue(all(step[1] >= 0.4 for step in pattern))
 
     def test_photo_ok_uses_selected_sound(self) -> None:
         device = buzzer.ShutterBuzzer(None, photo_sound="sparkle")
@@ -160,12 +166,22 @@ class ShutterBuzzerTest(unittest.TestCase):
         device._device = fake
         device._active = False
 
-        device._play_tone(1700.0, 0.004)
+        device._play_tone(1700.0, 0.040)
 
         self.assertEqual(fake.frequency, 1700.0)
         self.assertGreater(fake.value_history.count(buzzer._CARRIER_DUTY), 1)
         self.assertGreater(fake.value_history.count(0.0), 1)
         self.assertEqual(fake.value, 0.0)
+
+    def test_partial_volume_burst_contains_complete_carrier_cycles(self) -> None:
+        on_slice, off_slice = buzzer._burst_slices(1500.0, 0.16)
+
+        self.assertGreaterEqual(
+            on_slice * 1500.0,
+            buzzer._MIN_CARRIER_CYCLES_PER_BURST,
+        )
+        self.assertGreater(on_slice, 0.001)
+        self.assertGreater(off_slice, 0.0)
 
     def test_zero_volume_stays_silent(self) -> None:
         device = buzzer.ShutterBuzzer(None, volume=0.0)


### PR DESCRIPTION
## Summary

- slow the volume gate and guarantee at least three complete carrier cycles per active slice
- lengthen the photo cues and distinguish them through both pitch and rhythm
- add a sustained 1.5 kHz / 2.5 kHz `pitch-test` for identifying fixed-pitch active buzzer modules
- document the hardware diagnostic and corrected playback behavior

## Root cause

The previous 1 ms volume gate enabled the carrier for only 0.16 ms at the default volume. That is shorter than one cycle of a 1.5 kHz note, so the volume gate masked the requested carrier frequency and made different presets sound nearly identical.

Playback now uses a slower gate and dynamically ensures that every active slice contains at least three complete cycles. The presets also use distinct pulse counts, so their rhythms remain recognizable on active buzzers that cannot vary pitch.

## Hardware diagnostic

```bash
python3 src/tiny-film-cam/buzzer.py --sound pitch-test --volume 1.0
```

A passive buzzer produces two clearly different pitches. Identical pitches indicate an active buzzer with a built-in oscillator.

## Validation

- `python3 -m unittest discover -s tests -v` (31 tests passed)
- `python3 src/tiny-film-cam/buzzer.py --help`
- `git diff --check`
