### PR TITLE
Set startup and photo buzzer cues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,11 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
-# Photo cue: gentle (default), shutter, sparkle, or minimal.
-TINY_FILM_BUZZER_PHOTO_SOUND=gentle
+# Photo cue: minimal (default), gentle, shutter, or sparkle.
+TINY_FILM_BUZZER_PHOTO_SOUND=minimal
 # Loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. Try 0.10 quieter / 0.3 louder.
-TINY_FILM_BUZZER_VOLUME=0.16
+# alone does nothing on transistor modules. Full volume is the default.
+TINY_FILM_BUZZER_VOLUME=1.0
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,11 +5,11 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **click** | A very short acknowledgement when the button fires |
-| **gentle** | Photo saved (default; a soft descending two-note cue) |
-| **shutter** | Photo saved option with three dry mechanical-style taps |
-| **sparkle** | Photo saved option with a quick ascending major chord |
-| **minimal** | Photo saved option with one low tick |
+| **sparkle** | Shutter daemon initialized successfully; also a photo option |
+| **minimal** | Photo saved (default; one low tick) |
+| **gentle** | Photo saved option with a descending two-note cue |
+| **shutter** | Photo saved option with two dry mechanical-style taps |
+| **click** | A very short acknowledgement when video recording starts |
 | **chirp** | Video recording started |
 | **double** | Video saved |
 | **alert** | Capture or recording failed |
@@ -48,10 +48,10 @@ python3 src/tiny-film-cam/buzzer.py
 Or audition the four photo sounds individually:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.16
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.16
-python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 0.16
-python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.16
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 1.0
 ```
 
 The old `--sound beep` name remains as an alias for `gentle`.
@@ -83,6 +83,15 @@ python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 ## Using it with the shutter
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
+With the defaults, a full-volume `sparkle` plays once when the shutter daemon
+is ready, and a full-volume `minimal` tick plays after each photo is saved.
+If an existing `.env` overrides older buzzer defaults, set:
+
+```bash
+TINY_FILM_BUZZER_PHOTO_SOUND=minimal
+TINY_FILM_BUZZER_VOLUME=1.0
+```
+
 Restart the shutter service after deploying code that includes the buzzer:
 
 ```bash
@@ -111,8 +120,8 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
-| Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `gentle` |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.16` (burst density) |
+| Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `minimal` |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `1.0` (full) |
 
 ## Notes
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,7 +63,8 @@ python3 src/tiny-film-cam/buzzer.py
 
 ## Play one buzzer sound
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.16
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 1.0
 ```
 
 ## Check whether the buzzer can change pitch

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -8,10 +8,10 @@ import time
 LOGGER = logging.getLogger("tiny_film.buzzer")
 
 # Volume is burst density (0–1), not PWM duty — transistor modules ignore
-# duty cycle and stay full-loud whenever the pin is high. A restrained default
-# keeps the little piezo from dominating the moment.
-DEFAULT_VOLUME = 0.16
-DEFAULT_PHOTO_SOUND = "gentle"
+# duty cycle and stay full-loud whenever the pin is high.
+DEFAULT_VOLUME = 1.0
+DEFAULT_PHOTO_SOUND = "minimal"
+READY_SOUND = "sparkle"
 
 # Gate the carrier slowly enough that every "on" slice contains several
 # complete tone cycles. The old 1 ms gate produced 0.16 ms slices at the
@@ -133,6 +133,10 @@ class ShutterBuzzer:
     @property
     def enabled(self) -> bool:
         return self._device is not None
+
+    def ready(self) -> None:
+        """Confirmation that the shutter daemon initialized successfully."""
+        self.play(READY_SOUND)
 
     def click(self) -> None:
         """Short tick when the shutter button fires."""

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -266,7 +266,6 @@ def main() -> None:
 
         try:
             LOGGER.info("Button pressed; capturing photo")
-            buzzer.click()
             settings = CaptureSettings(
                 output_dir=output_dir,
                 width=args.width,
@@ -366,6 +365,7 @@ def main() -> None:
             args.buzzer_volume,
             args.buzzer_photo_sound,
         )
+        buzzer.ready()
     elif args.no_buzzer or buzzer_pin is None:
         LOGGER.info("Buzzer feedback disabled")
 

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -48,6 +48,7 @@ class ShutterBuzzerTest(unittest.TestCase):
         device = buzzer.ShutterBuzzer(None)
 
         self.assertFalse(device.enabled)
+        device.ready()
         device.click()
         device.photo_ok()
         device.video_start()
@@ -120,6 +121,23 @@ class ShutterBuzzerTest(unittest.TestCase):
         device.photo_ok()
 
         device.play.assert_called_once_with("sparkle")
+
+    def test_ready_uses_sparkle(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        device.play = MagicMock()
+
+        device.ready()
+
+        device.play.assert_called_once_with("sparkle")
+
+    def test_photo_defaults_to_minimal_at_full_volume(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        device.play = MagicMock()
+
+        device.photo_ok()
+
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
+        device.play.assert_called_once_with("minimal")
 
     def test_unknown_photo_sound_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "Unknown photo sound"):
@@ -199,8 +217,8 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
         self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
 
-    def test_default_volume_is_restrained(self) -> None:
-        self.assertLessEqual(buzzer.DEFAULT_VOLUME, 0.2)
+    def test_default_volume_is_full(self) -> None:
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary

- play the full-volume `sparkle` cue after the shutter button and buzzer initialize successfully
- use the full-volume `minimal` cue after a photo is saved
- remove the extra pre-capture photo click so each photo produces one confirmation
- update CLI, environment, and documentation defaults to `minimal` at volume `1.0`

## Behavior

- Successful device startup: `sparkle`, equivalent to `--sound sparkle --volume 1.0`
- Successful image capture: `minimal`, equivalent to `--sound minimal --volume 1.0`
- Failed buzzer or button initialization does not produce the ready cue

Existing installations with older values in `.env` should use:

```bash
TINY_FILM_BUZZER_PHOTO_SOUND=minimal
TINY_FILM_BUZZER_VOLUME=1.0
```

## Validation

- `python3 -m unittest discover -s tests -v` (33 tests passed)
- `python3 src/tiny-film-cam/buzzer.py --help`
- `python3 src/tiny-film-cam/shutter_daemon.py --help`
- `git diff --check`
