### PR TITLE
Play photo cue at frame capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ TINY_FILM_BUZZER_ACTIVE=0
 # Photo cue: minimal (default), gentle, shutter, or sparkle.
 TINY_FILM_BUZZER_PHOTO_SOUND=minimal
 # Loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. Full volume is the default.
-TINY_FILM_BUZZER_VOLUME=1.0
+# alone does nothing on transistor modules. 0.35 is moderate; 1.0 is full.
+TINY_FILM_BUZZER_VOLUME=0.35
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -6,9 +6,9 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 | Sound | When |
 |-------|------|
 | **sparkle** | Shutter daemon initialized successfully; also a photo option |
-| **minimal** | Photo saved (default; one low tick) |
-| **gentle** | Photo saved option with a descending two-note cue |
-| **shutter** | Photo saved option with two dry mechanical-style taps |
+| **minimal** | Frame captured (default; one low tick) |
+| **gentle** | Frame-captured option with a descending two-note cue |
+| **shutter** | Frame-captured option with two dry mechanical-style taps |
 | **click** | A very short acknowledgement when video recording starts |
 | **chirp** | Video recording started |
 | **double** | Video saved |
@@ -48,10 +48,10 @@ python3 src/tiny-film-cam/buzzer.py
 Or audition the four photo sounds individually:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 1.0
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 1.0
-python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 1.0
-python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.35
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.35
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 0.35
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.35
 ```
 
 The old `--sound beep` name remains as an alias for `gentle`.
@@ -83,13 +83,14 @@ python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 ## Using it with the shutter
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
-With the defaults, a full-volume `sparkle` plays once when the shutter daemon
-is ready, and a full-volume `minimal` tick plays after each photo is saved.
+With the defaults, a moderate-volume `sparkle` plays once when the shutter
+daemon is ready. A moderate-volume `minimal` tick plays immediately after the
+camera captures a frame, before rotation, JPEG encoding, and disk saving.
 If an existing `.env` overrides older buzzer defaults, set:
 
 ```bash
 TINY_FILM_BUZZER_PHOTO_SOUND=minimal
-TINY_FILM_BUZZER_VOLUME=1.0
+TINY_FILM_BUZZER_VOLUME=0.35
 ```
 
 Restart the shutter service after deploying code that includes the buzzer:
@@ -121,7 +122,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
 | Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `minimal` |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `1.0` (full) |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.35` (moderate) |
 
 ## Notes
 
@@ -136,3 +137,6 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
   most of that hardware.
 - Burst volume gating retains at least three complete carrier cycles per pulse
   so low-volume playback does not mask the selected pitch.
+- Volume is burst density rather than electrical amplitude: `1.0` drives the
+  carrier continuously, while `0.35` drives it for roughly 35% of the playback
+  time. Perceived loudness is not linear and varies by buzzer module.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,8 +63,8 @@ python3 src/tiny-film-cam/buzzer.py
 
 ## Play one buzzer sound
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 1.0
-python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 0.35
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.35
 ```
 
 ## Check whether the buzzer can change pitch

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -9,7 +9,7 @@ LOGGER = logging.getLogger("tiny_film.buzzer")
 
 # Volume is burst density (0–1), not PWM duty — transistor modules ignore
 # duty cycle and stay full-loud whenever the pin is high.
-DEFAULT_VOLUME = 1.0
+DEFAULT_VOLUME = 0.35
 DEFAULT_PHOTO_SOUND = "minimal"
 READY_SOUND = "sparkle"
 
@@ -142,9 +142,13 @@ class ShutterBuzzer:
         """Short tick when the shutter button fires."""
         self.play("click")
 
-    def photo_ok(self) -> None:
-        """Confirmation that a photo was saved."""
+    def photo_captured(self) -> None:
+        """Cue emitted immediately after the camera returns a captured frame."""
         self.play(self._photo_sound)
+
+    def photo_ok(self) -> None:
+        """Backwards-compatible alias for the photo capture cue."""
+        self.photo_captured()
 
     def video_start(self) -> None:
         """Cue that video recording has started."""

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import fcntl
 import os
 from pathlib import Path
-from typing import Iterator, Literal
+from typing import Callable, Iterator, Literal
 
 
 Rotation = Literal[0, 90, 180, 270]
@@ -383,8 +383,30 @@ def _open_camera(Picamera2):
         ) from exc
 
 
-def capture_photos(settings: CaptureSettings = CaptureSettings()) -> list[Path]:
-    """Capture one or more still images from a Raspberry Pi Camera Module 3."""
+def _capture_and_save_image(
+    picam2,
+    settings: CaptureSettings,
+    output_path: Path,
+    on_captured: Callable[[], None] | None,
+) -> None:
+    """Capture a sensor frame, notify immediately, then process and save it."""
+    frame = picam2.capture_array("main")
+    if on_captured is not None:
+        on_captured()
+    image = _image_from_picamera_frame(frame)
+    image = _rotate_image(image, settings.rotation)
+    image.save(
+        output_path,
+        format="JPEG",
+        quality=_normalized_quality(settings.quality),
+    )
+
+
+def capture_photos(
+    settings: CaptureSettings = CaptureSettings(),
+    on_captured: Callable[[], None] | None = None,
+) -> list[Path]:
+    """Capture still images, notifying after each frame and before JPEG saving."""
     import time
 
     try:
@@ -432,13 +454,11 @@ def capture_photos(settings: CaptureSettings = CaptureSettings()) -> list[Path]:
                     if settings.bracket_settle_seconds > 0:
                         time.sleep(settings.bracket_settle_seconds)
 
-                frame = picam2.capture_array("main")
-                image = _image_from_picamera_frame(frame)
-                image = _rotate_image(image, settings.rotation)
-                image.save(
+                _capture_and_save_image(
+                    picam2,
+                    settings,
                     output_path,
-                    format="JPEG",
-                    quality=_normalized_quality(settings.quality),
+                    on_captured,
                 )
         finally:
             if started:

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -284,9 +284,11 @@ def main() -> None:
                 awb_mode=args.awb_mode,
                 awb_lock=args.awb_lock,
             )
-            output_paths = capture_photos(settings)
+            output_paths = capture_photos(
+                settings,
+                on_captured=buzzer.photo_captured,
+            )
             LOGGER.info("Saved %s photo(s): %s", len(output_paths), output_paths)
-            buzzer.photo_ok()
         except Exception:
             LOGGER.exception("Capture failed")
             buzzer.error()

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -50,6 +50,7 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertFalse(device.enabled)
         device.ready()
         device.click()
+        device.photo_captured()
         device.photo_ok()
         device.video_start()
         device.video_stop()
@@ -114,11 +115,11 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertEqual([step[0] for step in pattern], [1500.0, 2500.0])
         self.assertTrue(all(step[1] >= 0.4 for step in pattern))
 
-    def test_photo_ok_uses_selected_sound(self) -> None:
+    def test_photo_captured_uses_selected_sound(self) -> None:
         device = buzzer.ShutterBuzzer(None, photo_sound="sparkle")
         device.play = MagicMock()
 
-        device.photo_ok()
+        device.photo_captured()
 
         device.play.assert_called_once_with("sparkle")
 
@@ -130,14 +131,22 @@ class ShutterBuzzerTest(unittest.TestCase):
 
         device.play.assert_called_once_with("sparkle")
 
-    def test_photo_defaults_to_minimal_at_full_volume(self) -> None:
+    def test_photo_defaults_to_minimal_at_moderate_volume(self) -> None:
         device = buzzer.ShutterBuzzer(None)
         device.play = MagicMock()
 
+        device.photo_captured()
+
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 0.35)
+        device.play.assert_called_once_with("minimal")
+
+    def test_photo_ok_remains_an_alias(self) -> None:
+        device = buzzer.ShutterBuzzer(None)
+        device.photo_captured = MagicMock()
+
         device.photo_ok()
 
-        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
-        device.play.assert_called_once_with("minimal")
+        device.photo_captured.assert_called_once_with()
 
     def test_unknown_photo_sound_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "Unknown photo sound"):
@@ -217,8 +226,8 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
         self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
 
-    def test_default_volume_is_full(self) -> None:
-        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
+    def test_default_volume_is_moderate(self) -> None:
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 0.35)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
 import sys
 import unittest
-from unittest.mock import patch
-from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from PIL import Image
@@ -115,6 +115,32 @@ class CameraRotationTest(unittest.TestCase):
         self.assertEqual(image.mode, "RGB")
         self.assertEqual(image.getpixel((0, 0)), (255, 0, 0))
         self.assertEqual(image.getpixel((1, 0)), (0, 0, 255))
+
+    def test_capture_callback_runs_before_image_processing_and_save(self) -> None:
+        events: list[str] = []
+        picam2 = MagicMock()
+        picam2.capture_array.side_effect = lambda stream: events.append(
+            "captured"
+        ) or object()
+        image = MagicMock()
+        image.save.side_effect = lambda *args, **kwargs: events.append("saved")
+
+        with (
+            patch.object(
+                camera,
+                "_image_from_picamera_frame",
+                side_effect=lambda frame: events.append("processed") or image,
+            ),
+            patch.object(camera, "_rotate_image", return_value=image),
+        ):
+            camera._capture_and_save_image(
+                picam2,
+                camera.CaptureSettings(),
+                Path("photo.jpg"),
+                lambda: events.append("sound"),
+            )
+
+        self.assertEqual(events, ["captured", "sound", "processed", "saved"])
 
     def test_rotation_90_is_clockwise(self) -> None:
         rotated = camera._rotate_image(marker_image(), 90)


### PR DESCRIPTION
## Summary

- trigger the photo cue immediately after `capture_array()` returns a sensor frame
- play the cue before color conversion, rotation, JPEG encoding, and disk saving
- rename the event method to `photo_captured`, retaining `photo_ok` as a compatibility alias
- lower the default buzzer volume from `1.0` to `0.35`
- document burst-density volume behavior and the new moderate-volume commands

## Why

The photo cue previously played only after the complete capture pipeline returned, so rotation, JPEG encoding, and disk I/O delayed the feedback. It now starts at the actual frame-capture boundary.

Full volume continuously drives the passive buzzer carrier and was too loud. A default burst density of `0.35` drives the carrier for roughly 35% of playback time, making the same cues noticeably quieter while the pitch-preserving gate retains complete carrier cycles.

## Capture order

1. Sensor frame captured
2. Photo cue starts asynchronously
3. Frame converted and rotated
4. JPEG encoded and saved

## Validation

- `python3 -m unittest discover -s tests -v` (35 tests passed)
- `python3 -m compileall -q src tests`
- `git diff --check`
