### PR TITLE
Restore full buzzer volume default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ TINY_FILM_BUZZER_ACTIVE=0
 # Photo cue: minimal (default), gentle, shutter, or sparkle.
 TINY_FILM_BUZZER_PHOTO_SOUND=minimal
 # Loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. 0.35 is moderate; 1.0 is full.
-TINY_FILM_BUZZER_VOLUME=0.35
+# alone does nothing on transistor modules. Full volume is the default.
+TINY_FILM_BUZZER_VOLUME=1.0
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -48,10 +48,10 @@ python3 src/tiny-film-cam/buzzer.py
 Or audition the four photo sounds individually:
 
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.35
-python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 0.35
-python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 0.35
-python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.35
+python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound shutter --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 1.0
 ```
 
 The old `--sound beep` name remains as an alias for `gentle`.
@@ -83,14 +83,14 @@ python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 ## Using it with the shutter
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
-With the defaults, a moderate-volume `sparkle` plays once when the shutter
-daemon is ready. A moderate-volume `minimal` tick plays immediately after the
-camera captures a frame, before rotation, JPEG encoding, and disk saving.
+With the defaults, a full-volume `sparkle` plays once when the shutter daemon
+is ready. A full-volume `minimal` tick plays immediately after the camera
+captures a frame, before rotation, JPEG encoding, and disk saving.
 If an existing `.env` overrides older buzzer defaults, set:
 
 ```bash
 TINY_FILM_BUZZER_PHOTO_SOUND=minimal
-TINY_FILM_BUZZER_VOLUME=0.35
+TINY_FILM_BUZZER_VOLUME=1.0
 ```
 
 Restart the shutter service after deploying code that includes the buzzer:
@@ -122,7 +122,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
 | Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `minimal` |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.35` (moderate) |
+| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `1.0` (full) |
 
 ## Notes
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,8 +63,8 @@ python3 src/tiny-film-cam/buzzer.py
 
 ## Play one buzzer sound
 ```bash
-python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 0.35
-python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.35
+python3 src/tiny-film-cam/buzzer.py --sound sparkle --volume 1.0
+python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 1.0
 ```
 
 ## Check whether the buzzer can change pitch

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -9,7 +9,7 @@ LOGGER = logging.getLogger("tiny_film.buzzer")
 
 # Volume is burst density (0–1), not PWM duty — transistor modules ignore
 # duty cycle and stay full-loud whenever the pin is high.
-DEFAULT_VOLUME = 0.35
+DEFAULT_VOLUME = 1.0
 DEFAULT_PHOTO_SOUND = "minimal"
 READY_SOUND = "sparkle"
 

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -131,13 +131,13 @@ class ShutterBuzzerTest(unittest.TestCase):
 
         device.play.assert_called_once_with("sparkle")
 
-    def test_photo_defaults_to_minimal_at_moderate_volume(self) -> None:
+    def test_photo_defaults_to_minimal_at_full_volume(self) -> None:
         device = buzzer.ShutterBuzzer(None)
         device.play = MagicMock()
 
         device.photo_captured()
 
-        self.assertEqual(buzzer.DEFAULT_VOLUME, 0.35)
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
         device.play.assert_called_once_with("minimal")
 
     def test_photo_ok_remains_an_alias(self) -> None:
@@ -226,8 +226,8 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
         self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
 
-    def test_default_volume_is_moderate(self) -> None:
-        self.assertEqual(buzzer.DEFAULT_VOLUME, 0.35)
+    def test_default_volume_is_full(self) -> None:
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary

- restore `1.0` as the default buzzer volume
- update `.env.example`, audition commands, and buzzer documentation
- update tests to lock in full-volume behavior

## Why

Full volume keeps the passive buzzer carrier continuous and preserves the preferred smooth tone. Physical damping can reduce acoustic loudness without introducing burst-gating texture.

The startup cue remains `sparkle`, and the frame-capture cue remains `minimal`.

## Validation

- `python3 -m unittest discover -s tests -v` (35 tests passed)
- `git diff --check`
