### PR TITLE
Use softer ready and photo buzzer cues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,13 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
-# Photo cue: minimal (default), gentle, shutter, or sparkle.
-TINY_FILM_BUZZER_PHOTO_SOUND=minimal
-# Loudness for passive buzzers (0.0–1.0). Uses burst density — duty cycle
-# alone does nothing on transistor modules. Full volume is the default.
-TINY_FILM_BUZZER_VOLUME=1.0
+# Photo cue: click (default), minimal, gentle, shutter, or sparkle.
+TINY_FILM_BUZZER_PHOTO_SOUND=click
+# Loudness for ready/video/error cues (0.0–1.0). Uses burst density — duty
+# cycle alone does nothing on transistor modules.
+TINY_FILM_BUZZER_VOLUME=0.90
+# Softer loudness for the per-capture cue (plays right after the frame).
+TINY_FILM_BUZZER_PHOTO_VOLUME=0.30
 
 TINY_FILM_OUTPUT_DIR=data/captures
 TINY_FILM_CAPTURE_QUALITY=95

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,11 +5,11 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **sparkle** | Shutter daemon initialized successfully; also a photo option |
-| **minimal** | Frame captured (default; one low tick) |
+| **minimal** | Shutter daemon initialized successfully (default ready cue) |
+| **click** | Frame captured (default; shorter/softer tick than minimal) |
 | **gentle** | Frame-captured option with a descending two-note cue |
 | **shutter** | Frame-captured option with two dry mechanical-style taps |
-| **click** | A very short acknowledgement when video recording starts |
+| **sparkle** | Frame-captured option with a bright three-note arpeggio |
 | **chirp** | Video recording started |
 | **double** | Video saved |
 | **alert** | Capture or recording failed |
@@ -83,14 +83,15 @@ python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 ## Using it with the shutter
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
-With the defaults, a full-volume `sparkle` plays once when the shutter daemon
-is ready. A full-volume `minimal` tick plays immediately after the camera
-captures a frame, before rotation, JPEG encoding, and disk saving.
+With the defaults, `minimal` at volume `0.90` plays once when the shutter
+daemon is ready. A softer `click` at volume `0.30` plays immediately after the
+camera returns a frame, before rotation, JPEG encoding, and disk saving.
 If an existing `.env` overrides older buzzer defaults, set:
 
 ```bash
-TINY_FILM_BUZZER_PHOTO_SOUND=minimal
-TINY_FILM_BUZZER_VOLUME=1.0
+TINY_FILM_BUZZER_PHOTO_SOUND=click
+TINY_FILM_BUZZER_VOLUME=0.90
+TINY_FILM_BUZZER_PHOTO_VOLUME=0.30
 ```
 
 Restart the shutter service after deploying code that includes the buzzer:
@@ -121,8 +122,9 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
-| Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `minimal` |
-| Volume (passive) | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `1.0` (full) |
+| Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `click` |
+| Ready/video volume | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.90` |
+| Photo volume | `TINY_FILM_BUZZER_PHOTO_VOLUME` | `--buzzer-photo-volume` | `0.30` |
 
 ## Notes
 

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -9,9 +9,10 @@ LOGGER = logging.getLogger("tiny_film.buzzer")
 
 # Volume is burst density (0–1), not PWM duty — transistor modules ignore
 # duty cycle and stay full-loud whenever the pin is high.
-DEFAULT_VOLUME = 1.0
-DEFAULT_PHOTO_SOUND = "minimal"
-READY_SOUND = "sparkle"
+DEFAULT_VOLUME = 0.90
+DEFAULT_PHOTO_VOLUME = 0.30
+DEFAULT_PHOTO_SOUND = "click"
+READY_SOUND = "minimal"
 
 # Gate the carrier slowly enough that every "on" slice contains several
 # complete tone cycles. The old 1 ms gate produced 0.16 ms slices at the
@@ -33,10 +34,10 @@ _G6 = 1568.0
 _B6 = 1976.0
 _D7 = 2349.0
 
-PHOTO_SOUNDS = ("gentle", "shutter", "sparkle", "minimal")
+PHOTO_SOUNDS = ("click", "minimal", "gentle", "shutter", "sparkle")
 
 SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
-    # A clearly audible, resolving major-third fall. This is the default cue.
+    # A clearly audible, resolving major-third fall.
     "gentle": ((_B6, 0.090, 0.035), (_G6, 0.130, 0.0)),
     # Dry high/low taps that suggest a mechanical shutter rather than a beep.
     "shutter": (
@@ -49,9 +50,9 @@ SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
         (_B6, 0.065, 0.025),
         (_D7, 0.110, 0.0),
     ),
-    # The least intrusive option: one low, very short tick.
+    # Soft ready cue: one low, short tick.
     "minimal": ((_G6, 0.045, 0.0),),
-    # Semantic cues used elsewhere in the shutter daemon.
+    # Default photo cue: same pitch as minimal, even shorter.
     "click": ((_G6, 0.025, 0.0),),
     "chirp": ((_G6, 0.080, 0.030), (_B6, 0.130, 0.0)),
     "double": ((_B6, 0.070, 0.060), (_G6, 0.100, 0.0)),
@@ -64,7 +65,7 @@ SOUNDS: dict[str, tuple[tuple[float, float, float], ...]] = {
 SOUNDS["beep"] = SOUNDS["gentle"]
 
 # The no-argument hardware demo focuses on distinct sounds, not aliases.
-SOUND_ORDER = PHOTO_SOUNDS + ("chirp", "double", "alert")
+SOUND_ORDER = ("gentle", "shutter", "sparkle", "minimal", "click", "chirp", "double", "alert")
 
 
 def clamp_volume(volume: float) -> float:
@@ -98,6 +99,7 @@ class ShutterBuzzer:
         pin: int | None,
         active: bool = False,
         volume: float = DEFAULT_VOLUME,
+        photo_volume: float = DEFAULT_PHOTO_VOLUME,
         photo_sound: str = DEFAULT_PHOTO_SOUND,
     ) -> None:
         if photo_sound not in PHOTO_SOUNDS:
@@ -107,6 +109,7 @@ class ShutterBuzzer:
             )
         self._active = active
         self._volume = clamp_volume(volume)
+        self._photo_volume = clamp_volume(photo_volume)
         self._photo_sound = photo_sound
         self._device = None
         self._lock = threading.Lock()
@@ -136,15 +139,15 @@ class ShutterBuzzer:
 
     def ready(self) -> None:
         """Confirmation that the shutter daemon initialized successfully."""
-        self.play(READY_SOUND)
+        self.play(READY_SOUND, volume=self._volume)
 
     def click(self) -> None:
         """Short tick when the shutter button fires."""
-        self.play("click")
+        self.play("click", volume=self._photo_volume)
 
     def photo_captured(self) -> None:
         """Cue emitted immediately after the camera returns a captured frame."""
-        self.play(self._photo_sound)
+        self.play(self._photo_sound, volume=self._photo_volume)
 
     def photo_ok(self) -> None:
         """Backwards-compatible alias for the photo capture cue."""
@@ -152,51 +155,63 @@ class ShutterBuzzer:
 
     def video_start(self) -> None:
         """Cue that video recording has started."""
-        self.play("chirp")
+        self.play("chirp", volume=self._volume)
 
     def video_stop(self) -> None:
         """Cue that video recording finished and was saved."""
-        self.play("double")
+        self.play("double", volume=self._volume)
 
     def error(self) -> None:
         """Alert tone when capture or recording fails."""
-        self.play("alert")
+        self.play("alert", volume=self._volume)
 
-    def play(self, name: str) -> None:
+    def play(self, name: str, volume: float | None = None) -> None:
         pattern = SOUNDS.get(name)
         if pattern is None:
             raise ValueError(f"Unknown buzzer sound: {name!r}")
-        self._play(pattern)
+        self._play(pattern, volume=self._volume if volume is None else volume)
 
     def play_all(self, pause_seconds: float = 0.4) -> None:
         """Play every built-in sound once — useful for hardware bring-up."""
         for name in SOUND_ORDER:
             LOGGER.info("Playing buzzer sound %s", name)
-            self._run_pattern(SOUNDS[name])
+            self._run_pattern(SOUNDS[name], volume=self._volume)
             if pause_seconds:
                 time.sleep(pause_seconds)
 
-    def _play(self, pattern: tuple[tuple[float, float, float], ...]) -> None:
+    def _play(self, pattern: tuple[tuple[float, float, float], ...], volume: float) -> None:
         if self._device is None:
             return
         thread = threading.Thread(
-            target=self._run_pattern, args=(pattern,), daemon=True
+            target=self._run_pattern,
+            args=(pattern, clamp_volume(volume)),
+            daemon=True,
         )
         thread.start()
 
-    def _run_pattern(self, pattern: tuple[tuple[float, float, float], ...]) -> None:
+    def _run_pattern(
+        self,
+        pattern: tuple[tuple[float, float, float], ...],
+        volume: float | None = None,
+    ) -> None:
         # Serialise playback so overlapping captures don't fight over the pin.
+        play_volume = self._volume if volume is None else clamp_volume(volume)
         with self._lock:
             try:
                 for frequency, on_seconds, gap_seconds in pattern:
-                    self._play_tone(frequency, on_seconds)
+                    self._play_tone(frequency, on_seconds, volume=play_volume)
                     if gap_seconds:
                         time.sleep(gap_seconds)
             except Exception:
                 LOGGER.exception("Buzzer playback failed")
                 self._tone_off()
 
-    def _play_tone(self, frequency: float, on_seconds: float) -> None:
+    def _play_tone(
+        self,
+        frequency: float,
+        on_seconds: float,
+        volume: float | None = None,
+    ) -> None:
         if self._device is None or on_seconds <= 0:
             return
         if self._active:
@@ -205,12 +220,13 @@ class ShutterBuzzer:
             self._device.off()
             return
 
-        if self._volume <= 0:
+        play_volume = self._volume if volume is None else clamp_volume(volume)
+        if play_volume <= 0:
             time.sleep(on_seconds)
             return
 
         self._device.frequency = max(1.0, frequency)
-        if self._volume >= 1.0:
+        if play_volume >= 1.0:
             self._device.value = _CARRIER_DUTY
             time.sleep(on_seconds)
             self._tone_off()
@@ -219,7 +235,7 @@ class ShutterBuzzer:
         # Burst-gate the carrier so volume changes are audible on modules that
         # only hard-switch VCC to the piezo (duty cycle alone does nothing).
         # Each slice includes enough complete cycles to retain the tone.
-        on_slice, off_slice = _burst_slices(frequency, self._volume)
+        on_slice, off_slice = _burst_slices(frequency, play_volume)
         deadline = time.monotonic() + on_seconds
         while True:
             remaining = deadline - time.monotonic()

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from buzzer import (
     DEFAULT_PHOTO_SOUND,
+    DEFAULT_PHOTO_VOLUME,
     DEFAULT_VOLUME,
     PHOTO_SOUNDS,
     ShutterBuzzer,
@@ -117,8 +118,17 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=env_float("TINY_FILM_BUZZER_VOLUME", DEFAULT_VOLUME),
         help=(
-            "Passive buzzer loudness 0.0–1.0 via burst density "
+            "Passive buzzer loudness for ready/video/error cues 0.0–1.0 "
             f"(default: {DEFAULT_VOLUME})."
+        ),
+    )
+    parser.add_argument(
+        "--buzzer-photo-volume",
+        type=float,
+        default=env_float("TINY_FILM_BUZZER_PHOTO_VOLUME", DEFAULT_PHOTO_VOLUME),
+        help=(
+            "Passive buzzer loudness for the photo capture cue 0.0–1.0 "
+            f"(default: {DEFAULT_PHOTO_VOLUME})."
         ),
     )
     parser.add_argument(
@@ -128,7 +138,7 @@ def parse_args() -> argparse.Namespace:
             "TINY_FILM_BUZZER_PHOTO_SOUND", DEFAULT_PHOTO_SOUND
         ),
         help=(
-            "Photo-saved cue: gentle, shutter, sparkle, or minimal "
+            "Photo capture cue: click, minimal, gentle, shutter, or sparkle "
             f"(default: {DEFAULT_PHOTO_SOUND})."
         ),
     )
@@ -244,6 +254,7 @@ def main() -> None:
         buzzer_pin,
         active=args.buzzer_active,
         volume=args.buzzer_volume,
+        photo_volume=args.buzzer_photo_volume,
         photo_sound=args.buzzer_photo_sound,
     )
 
@@ -361,11 +372,12 @@ def main() -> None:
     if buzzer.enabled:
         buzzer_kind = "active" if args.buzzer_active else "passive"
         LOGGER.info(
-            "Buzzer feedback on BCM GPIO %s (%s, volume=%.2f, photo=%s)",
+            "Buzzer feedback on BCM GPIO %s (%s, volume=%.2f, photo=%s@%.2f)",
             buzzer_pin,
             buzzer_kind,
             args.buzzer_volume,
             args.buzzer_photo_sound,
+            args.buzzer_photo_volume,
         )
         buzzer.ready()
     elif args.no_buzzer or buzzer_pin is None:

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -86,6 +86,7 @@ class ShutterBuzzerTest(unittest.TestCase):
                 "shutter",
                 "sparkle",
                 "minimal",
+                "click",
                 "chirp",
                 "double",
                 "alert",
@@ -116,29 +117,35 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertTrue(all(step[1] >= 0.4 for step in pattern))
 
     def test_photo_captured_uses_selected_sound(self) -> None:
-        device = buzzer.ShutterBuzzer(None, photo_sound="sparkle")
+        device = buzzer.ShutterBuzzer(
+            None, photo_sound="sparkle", photo_volume=0.45
+        )
         device.play = MagicMock()
 
         device.photo_captured()
 
-        device.play.assert_called_once_with("sparkle")
+        device.play.assert_called_once_with("sparkle", volume=0.45)
 
-    def test_ready_uses_sparkle(self) -> None:
+    def test_ready_uses_minimal_at_ready_volume(self) -> None:
         device = buzzer.ShutterBuzzer(None)
         device.play = MagicMock()
 
         device.ready()
 
-        device.play.assert_called_once_with("sparkle")
+        device.play.assert_called_once_with("minimal", volume=buzzer.DEFAULT_VOLUME)
 
-    def test_photo_defaults_to_minimal_at_full_volume(self) -> None:
+    def test_photo_defaults_to_click_at_photo_volume(self) -> None:
         device = buzzer.ShutterBuzzer(None)
         device.play = MagicMock()
 
         device.photo_captured()
 
-        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
-        device.play.assert_called_once_with("minimal")
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 0.90)
+        self.assertEqual(buzzer.DEFAULT_PHOTO_VOLUME, 0.30)
+        self.assertEqual(buzzer.DEFAULT_PHOTO_SOUND, "click")
+        device.play.assert_called_once_with(
+            "click", volume=buzzer.DEFAULT_PHOTO_VOLUME
+        )
 
     def test_photo_ok_remains_an_alias(self) -> None:
         device = buzzer.ShutterBuzzer(None)
@@ -226,8 +233,9 @@ class ShutterBuzzerTest(unittest.TestCase):
         self.assertEqual(buzzer.clamp_volume(1.5), 1.0)
         self.assertEqual(buzzer.clamp_volume(0.16), 0.16)
 
-    def test_default_volume_is_full(self) -> None:
-        self.assertEqual(buzzer.DEFAULT_VOLUME, 1.0)
+    def test_default_volumes(self) -> None:
+        self.assertEqual(buzzer.DEFAULT_VOLUME, 0.90)
+        self.assertEqual(buzzer.DEFAULT_PHOTO_VOLUME, 0.30)
 
     def test_close_releases_device(self) -> None:
         device = buzzer.ShutterBuzzer(None)


### PR DESCRIPTION
## Summary
- Default startup cue is now `minimal` at volume `0.90`
- Default photo cue is now `click` at volume `0.30`, still played immediately after frame capture (before JPEG save)
- Add separate `TINY_FILM_BUZZER_PHOTO_VOLUME` / `--buzzer-photo-volume` so ready and capture loudness can differ

## Test plan
- [ ] On the Pi, stop the shutter service and audition: `python3 src/tiny-film-cam/buzzer.py --sound minimal --volume 0.90` then `--sound click --volume 0.30`
- [ ] Restart `tiny-film-shutter.service` and confirm ready cue on start
- [ ] Press the shutter button and confirm a quieter click right when the frame is taken, not after save finishes
- [ ] If an existing `.env` overrides older defaults, set `TINY_FILM_BUZZER_PHOTO_SOUND=click`, `TINY_FILM_BUZZER_VOLUME=0.90`, and `TINY_FILM_BUZZER_PHOTO_VOLUME=0.30`


Made with [Cursor](https://cursor.com)