### PR TITLE
Add three-position filter switch input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,22 @@
 TINY_FILM_WEB_HOST=0.0.0.0
 TINY_FILM_WEB_PORT=8000
 
+# SS23D32 three-position photo-filter switch. Wire one pole with its common
+# terminal to GND, then its outer terminals to BCM GPIO 27 and BCM GPIO 22.
+# The Pi's internal pull-ups are used; no external resistors are required.
+TINY_FILM_FILTER_LEFT_PIN=27
+TINY_FILM_FILTER_RIGHT_PIN=22
+TINY_FILM_FILTER_LEFT=black_and_white
+TINY_FILM_FILTER_CENTER=current
+TINY_FILM_FILTER_RIGHT=cold
+TINY_FILM_FILTER_CACHE_PATH=data/filter-state.json
+TINY_FILM_FILTER_POLL_SECONDS=0.05
+TINY_FILM_FILTER_DEBOUNCE_SECONDS=0.08
+TINY_FILM_FILTER_HEARTBEAT_SECONDS=5
+TINY_FILM_FILTER_STALE_SECONDS=15
+# For development without GPIO: left, center, or right. Leave blank on the Pi.
+TINY_FILM_FILTER_SIMULATE_POSITION=
+
 # Waveshare UPS HAT (C) battery monitor.
 TINY_FILM_BATTERY_I2C_BUS=1
 TINY_FILM_BATTERY_I2C_ADDRESS=0x43

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ images/
 
 data/captures/
 data/battery.json
+data/filter-state.json

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ video clip. Both appear in the gallery below.
 
 ## Boot services
 
-Install the web app, physical shutter, and battery monitor services on the
-Raspberry Pi:
+Install the web app, physical shutter, battery monitor, and photo-filter switch
+services on the Raspberry Pi:
 
 ```bash
 ./scripts/install_service.sh --enable-now
@@ -29,19 +29,19 @@ After pulling new changes, restart the services:
 
 ```bash
 git pull
-sudo systemctl restart tiny-film-web.service tiny-film-shutter.service tiny-film-battery.service
+sudo systemctl restart tiny-film-web.service tiny-film-shutter.service tiny-film-battery.service tiny-film-filter.service
 ```
 
 Check service status:
 
 ```bash
-sudo systemctl status tiny-film-web.service tiny-film-shutter.service tiny-film-battery.service --no-pager
+sudo systemctl status tiny-film-web.service tiny-film-shutter.service tiny-film-battery.service tiny-film-filter.service --no-pager
 ```
 
 Follow live service logs:
 
 ```bash
-sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -u tiny-film-battery.service -f
+sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -u tiny-film-battery.service -u tiny-film-filter.service -f
 ```
 
 The web service starts the phone app on port `8000`. The phone app and shutter
@@ -57,6 +57,11 @@ and writes `data/battery.json`. The web app exposes the latest reading at
 `GET /api/battery`, including percent remaining, voltage, current, power, and
 charging state. The percent is a voltage-derived estimate, so it can read high
 while the HAT is plugged into USB power.
+
+An optional SS23D32 three-position switch can select Black & white, the current
+look, or Cold for photos. It uses BCM GPIO 27 and 22 with internal pull-ups, so
+no external resistors are needed. See [docs/filter-switch.md](docs/filter-switch.md)
+for wiring and the live GPIO test command.
 
 To change the button pin or capture settings, copy `.env.example` to `.env` and
 edit the `TINY_FILM_*` values.

--- a/deploy/tiny-film-filter.service
+++ b/deploy/tiny-film-filter.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Tiny Film photo filter switch
+After=local-fs.target
+
+[Service]
+Type=simple
+User=__SERVICE_USER__
+WorkingDirectory=__PROJECT_ROOT__
+EnvironmentFile=-__PROJECT_ROOT__/.env
+ExecStart=__PROJECT_ROOT__/scripts/run_filter_switch.sh
+Restart=on-failure
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/filter-switch-plan.md
+++ b/docs/filter-switch-plan.md
@@ -4,8 +4,8 @@
 
 Use a physical three-position selector for the default photo looks:
 
-- left: **Warm**
-- centre: **Black & white**
+- left: **Black & white**
+- centre: **Current**
 - right: **Cold**
 
 The selected look is baked into new JPEGs from both the physical shutter and
@@ -49,8 +49,8 @@ These pins avoid the existing shutter (BCM 17), buzzer (BCM 18), and UPS I2C
 
 | GPIO 27 | GPIO 22 | Selection |
 | --- | --- | --- |
-| LOW | HIGH | Warm |
-| HIGH | HIGH | Black & white |
+| LOW | HIGH | Black & white |
+| HIGH | HIGH | Current |
 | HIGH | LOW | Cold |
 | LOW | LOW | invalid wiring/state |
 
@@ -79,7 +79,7 @@ cache immediately before each photo.
 
 Use a short debounce window and retain the last valid selection during a switch
 transition. If the service/cache is unavailable, use a clearly reported,
-configurable fallback (initially Warm) rather than guessing from stale GPIO
+configurable fallback (initially Current) rather than guessing from stale GPIO
 data.
 
 ## Delivery sequence

--- a/docs/filter-switch.md
+++ b/docs/filter-switch.md
@@ -1,0 +1,54 @@
+# Photo filter switch
+
+The SS23D32 three-position switch selects **Black & white**, the **current**
+camera look, or **Cold**. Version 1 applies the selection to photos only.
+
+## Wiring
+
+Power off the Pi before wiring. Use one row of three switch terminals:
+
+```text
+outer A ── BCM GPIO 27 (physical pin 13)
+common  ── GND         (physical pin 14)
+outer B ── BCM GPIO 22 (physical pin 15)
+```
+
+Leave the second row of three terminals disconnected. The service enables the
+Pi's internal pull-up resistors, so no external resistor and no 3.3 V/5 V wire
+are needed.
+
+| GPIO 27 | GPIO 22 | Default selection |
+| --- | --- | --- |
+| LOW | HIGH | Black & white |
+| HIGH | HIGH | Current |
+| HIGH | LOW | Cold |
+| LOW | LOW | invalid wiring/state |
+
+The handle can operate opposite the contacted terminal. Swap the left/right
+configuration values if the physical order is reversed.
+
+## Test before enabling the service
+
+```bash
+sudo systemctl stop tiny-film-filter.service
+python3 src/tiny-film-cam/filter_switch_test.py
+```
+
+Move through all three positions and confirm the printed GPIO levels and
+selection. Press `Ctrl+C` when finished. Start the service again with:
+
+```bash
+sudo systemctl start tiny-film-filter.service
+```
+
+The service writes the debounced state to `data/filter-state.json`. For a local
+test without GPIO hardware:
+
+```bash
+TINY_FILM_FILTER_SIMULATE_POSITION=center ./scripts/run_filter_switch.sh
+```
+
+## Configuration
+
+The defaults are in `.env.example`. `TINY_FILM_FILTER_LEFT` and
+`TINY_FILM_FILTER_RIGHT` can be swapped without rewiring the switch.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,7 +42,10 @@
     BCM GPIO 18 (physical pin 12). The shutter daemon enables that pin by
     default — test with `python3 src/tiny-film-cam/buzzer.py`. See
     [buzzer.md](buzzer.md).
-12. Install the Tiny Film boot services:
+12. Optionally wire and test the SS23D32 photo-filter switch on BCM GPIO 27 and
+    22. See [filter-switch.md](filter-switch.md); no external resistors are
+    required.
+13. Install the Tiny Film boot services:
    ```bash
    ./scripts/install_service.sh --enable-now
    ```

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -61,7 +61,7 @@ install_service() {
 }
 
 if [[ ${PRINT_ONLY} -eq 1 ]]; then
-  for name in tiny-film-web tiny-film-shutter tiny-film-battery; do
+  for name in tiny-film-web tiny-film-shutter tiny-film-battery tiny-film-filter; do
     echo "# ${name}.service"
     render_service "${PROJECT_ROOT}/deploy/${name}.service"
     echo
@@ -72,21 +72,24 @@ fi
 chmod +x \
   "${PROJECT_ROOT}/scripts/run_web.sh" \
   "${PROJECT_ROOT}/scripts/run_shutter.sh" \
-  "${PROJECT_ROOT}/scripts/run_battery.sh"
+  "${PROJECT_ROOT}/scripts/run_battery.sh" \
+  "${PROJECT_ROOT}/scripts/run_filter_switch.sh"
 
 install_service tiny-film-web
 install_service tiny-film-shutter
 install_service tiny-film-battery
+install_service tiny-film-filter
 sudo systemctl daemon-reload
 
 if [[ ${ENABLE_NOW} -eq 1 ]]; then
   sudo systemctl enable --now \
     tiny-film-web.service \
     tiny-film-shutter.service \
-    tiny-film-battery.service
+    tiny-film-battery.service \
+    tiny-film-filter.service
 else
   echo "Enable on boot:"
-  echo "  sudo systemctl enable --now tiny-film-web.service tiny-film-shutter.service tiny-film-battery.service"
+  echo "  sudo systemctl enable --now tiny-film-web.service tiny-film-shutter.service tiny-film-battery.service tiny-film-filter.service"
 fi
 
 echo "Web status:"
@@ -95,5 +98,7 @@ echo "Shutter status:"
 echo "  sudo systemctl status tiny-film-shutter.service --no-pager"
 echo "Battery status:"
 echo "  sudo systemctl status tiny-film-battery.service --no-pager"
+echo "Filter switch status:"
+echo "  sudo systemctl status tiny-film-filter.service --no-pager"
 echo "Logs:"
-echo "  sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -u tiny-film-battery.service -f"
+echo "  sudo journalctl -u tiny-film-web.service -u tiny-film-shutter.service -u tiny-film-battery.service -u tiny-film-filter.service -f"

--- a/scripts/restart_services.sh
+++ b/scripts/restart_services.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 sudo systemctl restart \
   tiny-film-web.service \
   tiny-film-shutter.service \
-  tiny-film-battery.service
+  tiny-film-battery.service \
+  tiny-film-filter.service
 
 echo "All systems have been restarted"

--- a/scripts/run_filter_switch.sh
+++ b/scripts/run_filter_switch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PYTHON_BIN="${PROJECT_ROOT}/.venv/bin/python3"
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  PYTHON_BIN="$(command -v python3)"
+fi
+
+cd "${PROJECT_ROOT}"
+
+if [[ -f "${PROJECT_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${PROJECT_ROOT}/.env"
+  set +a
+fi
+
+exec "${PYTHON_BIN}" "${PROJECT_ROOT}/src/tiny-film-cam/filter_daemon.py" \
+  --project-root "${PROJECT_ROOT}"

--- a/src/tiny-film-cam/filter_daemon.py
+++ b/src/tiny-film-cam/filter_daemon.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+import signal
+import threading
+import time
+from typing import Callable
+
+from filter_switch import (
+    DEFAULT_LEFT_PIN,
+    DEFAULT_RIGHT_PIN,
+    build_filter_state,
+    contacts_for_position,
+    env_float,
+    env_int,
+    filter_cache_path_from_env,
+    write_filter_cache,
+)
+
+
+LOGGER = logging.getLogger("tiny_film.filter")
+DEFAULT_POLL_SECONDS = 0.05
+DEFAULT_DEBOUNCE_SECONDS = 0.08
+DEFAULT_HEARTBEAT_SECONDS = 5.0
+
+
+def default_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Monitor the Tiny Film three-position photo-filter switch."
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=default_project_root(),
+    )
+    parser.add_argument(
+        "--left-pin",
+        type=int,
+        default=env_int("TINY_FILM_FILTER_LEFT_PIN", DEFAULT_LEFT_PIN),
+    )
+    parser.add_argument(
+        "--right-pin",
+        type=int,
+        default=env_int("TINY_FILM_FILTER_RIGHT_PIN", DEFAULT_RIGHT_PIN),
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=env_float("TINY_FILM_FILTER_POLL_SECONDS", DEFAULT_POLL_SECONDS),
+    )
+    parser.add_argument(
+        "--debounce-seconds",
+        type=float,
+        default=env_float(
+            "TINY_FILM_FILTER_DEBOUNCE_SECONDS", DEFAULT_DEBOUNCE_SECONDS
+        ),
+    )
+    parser.add_argument(
+        "--heartbeat-seconds",
+        type=float,
+        default=env_float(
+            "TINY_FILM_FILTER_HEARTBEAT_SECONDS", DEFAULT_HEARTBEAT_SECONDS
+        ),
+    )
+    parser.add_argument(
+        "--simulate-position",
+        choices=("left", "center", "right"),
+        default=os.environ.get("TINY_FILM_FILTER_SIMULATE_POSITION") or None,
+        help="Write a simulated state without opening GPIO pins.",
+    )
+    return parser.parse_args()
+
+
+def monitor_contacts(
+    *,
+    read_contacts: Callable[[], tuple[bool, bool]],
+    write_state: Callable[[bool, bool], None],
+    stop_event: threading.Event,
+    poll_seconds: float,
+    debounce_seconds: float,
+    heartbeat_seconds: float,
+) -> None:
+    poll_seconds = max(0.01, poll_seconds)
+    debounce_seconds = max(0.0, debounce_seconds)
+    heartbeat_seconds = max(0.5, heartbeat_seconds)
+    candidate = read_contacts()
+    candidate_since = time.monotonic()
+    accepted: tuple[bool, bool] | None = None
+    last_write = 0.0
+
+    while not stop_event.is_set():
+        now = time.monotonic()
+        contacts = read_contacts()
+        if contacts != candidate:
+            candidate = contacts
+            candidate_since = now
+
+        stable = now - candidate_since >= debounce_seconds
+        state_changed = stable and candidate != accepted
+        heartbeat_due = accepted is not None and now - last_write >= heartbeat_seconds
+        if state_changed:
+            accepted = candidate
+        if state_changed or heartbeat_due:
+            assert accepted is not None
+            write_state(*accepted)
+            last_write = now
+
+        stop_event.wait(poll_seconds)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    args = parse_args()
+    project_root = args.project_root.expanduser().resolve()
+    cache_path = filter_cache_path_from_env(project_root)
+    stop_event = threading.Event()
+
+    def request_stop(signum: int, frame: object) -> None:
+        LOGGER.info("Stopping on signal %s", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+
+    left_input = None
+    right_input = None
+    simulated_position = args.simulate_position
+    if simulated_position is not None:
+        simulated_contacts = contacts_for_position(simulated_position)
+
+        def read_contacts() -> tuple[bool, bool]:
+            return simulated_contacts
+
+        LOGGER.info("Using simulated filter position %s", simulated_position)
+    else:
+        try:
+            from gpiozero import Button
+        except ImportError as exc:
+            raise SystemExit(
+                "Missing gpiozero. On the Raspberry Pi, install it with: "
+                "sudo apt install -y python3-gpiozero"
+            ) from exc
+
+        try:
+            left_input = Button(args.left_pin, pull_up=True)
+            right_input = Button(args.right_pin, pull_up=True)
+        except Exception as exc:
+            raise SystemExit(
+                "Could not open the filter switch GPIO pins. Check the wiring, "
+                "pin settings, and whether another process owns them."
+            ) from exc
+
+        def read_contacts() -> tuple[bool, bool]:
+            assert left_input is not None and right_input is not None
+            return left_input.is_pressed, right_input.is_pressed
+
+    last_logged: tuple[object, object] | None = None
+
+    def write_state(left_grounded: bool, right_grounded: bool) -> None:
+        nonlocal last_logged
+        payload = build_filter_state(
+            left_grounded=left_grounded,
+            right_grounded=right_grounded,
+            left_pin=args.left_pin,
+            right_pin=args.right_pin,
+            simulated=simulated_position is not None,
+        )
+        write_filter_cache(cache_path, payload)
+        current = (payload["position"], payload["selection"])
+        if current != last_logged:
+            if payload["ok"]:
+                LOGGER.info(
+                    "Filter switch: %s -> %s",
+                    payload["position"],
+                    payload["selection"],
+                )
+            else:
+                LOGGER.warning("%s", payload["error"])
+            last_logged = current
+
+    LOGGER.info(
+        "Tiny Film filter switch ready on BCM GPIO %s/%s; cache=%s",
+        args.left_pin,
+        args.right_pin,
+        cache_path,
+    )
+    try:
+        monitor_contacts(
+            read_contacts=read_contacts,
+            write_state=write_state,
+            stop_event=stop_event,
+            poll_seconds=args.poll_seconds,
+            debounce_seconds=args.debounce_seconds,
+            heartbeat_seconds=args.heartbeat_seconds,
+        )
+    finally:
+        if left_input is not None:
+            left_input.close()
+        if right_input is not None:
+            right_input.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tiny-film-cam/filter_switch.py
+++ b/src/tiny-film-cam/filter_switch.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import time
+from typing import Literal
+
+
+FilterPosition = Literal["left", "center", "right"]
+
+DEFAULT_LEFT_PIN = 27
+DEFAULT_RIGHT_PIN = 22
+DEFAULT_CACHE_PATH = "data/filter-state.json"
+DEFAULT_STALE_SECONDS = 15.0
+DEFAULT_LEFT_SELECTION = "black_and_white"
+DEFAULT_CENTER_SELECTION = "current"
+DEFAULT_RIGHT_SELECTION = "cold"
+
+
+def env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    return int(value, 0)
+
+
+def env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    return float(value)
+
+
+def resolve_project_path(project_root: Path, value: str | Path) -> Path:
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    return project_root / path
+
+
+def filter_cache_path_from_env(project_root: Path) -> Path:
+    cache_path = os.environ.get("TINY_FILM_FILTER_CACHE_PATH", DEFAULT_CACHE_PATH)
+    return resolve_project_path(project_root, cache_path)
+
+
+def position_selections_from_env() -> dict[FilterPosition, str]:
+    return {
+        "left": os.environ.get(
+            "TINY_FILM_FILTER_LEFT", DEFAULT_LEFT_SELECTION
+        ).strip()
+        or DEFAULT_LEFT_SELECTION,
+        "center": os.environ.get(
+            "TINY_FILM_FILTER_CENTER", DEFAULT_CENTER_SELECTION
+        ).strip()
+        or DEFAULT_CENTER_SELECTION,
+        "right": os.environ.get(
+            "TINY_FILM_FILTER_RIGHT", DEFAULT_RIGHT_SELECTION
+        ).strip()
+        or DEFAULT_RIGHT_SELECTION,
+    }
+
+
+def position_from_contacts(
+    left_grounded: bool,
+    right_grounded: bool,
+) -> FilterPosition | None:
+    """Map active-low switch contacts to one stable selector position."""
+    if left_grounded and not right_grounded:
+        return "left"
+    if not left_grounded and not right_grounded:
+        return "center"
+    if not left_grounded and right_grounded:
+        return "right"
+    return None
+
+
+def contacts_for_position(position: FilterPosition) -> tuple[bool, bool]:
+    if position == "left":
+        return True, False
+    if position == "center":
+        return False, False
+    return False, True
+
+
+def build_filter_state(
+    *,
+    left_grounded: bool,
+    right_grounded: bool,
+    left_pin: int = DEFAULT_LEFT_PIN,
+    right_pin: int = DEFAULT_RIGHT_PIN,
+    timestamp: float | None = None,
+    simulated: bool = False,
+) -> dict[str, object]:
+    position = position_from_contacts(left_grounded, right_grounded)
+    payload: dict[str, object] = {
+        "ok": position is not None,
+        "timestamp_unix": time.time() if timestamp is None else timestamp,
+        "source": "simulated" if simulated else "ss23d32",
+        "position": position or "invalid",
+        "left_pin": left_pin,
+        "right_pin": right_pin,
+        "left_grounded": left_grounded,
+        "right_grounded": right_grounded,
+    }
+    if position is None:
+        payload["selection"] = None
+        payload["error"] = "Both switch inputs are grounded; check the wiring."
+    else:
+        payload["selection"] = position_selections_from_env()[position]
+    return payload
+
+
+def unavailable_filter_payload(
+    error: str,
+    *,
+    include_timestamp: bool = True,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ok": False,
+        "source": "ss23d32",
+        "position": "unavailable",
+        "selection": None,
+        "error": error,
+    }
+    if include_timestamp:
+        payload["timestamp_unix"] = time.time()
+    return payload
+
+
+def write_filter_cache(cache_path: Path, payload: dict[str, object]) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = cache_path.with_name(f".{cache_path.name}.tmp")
+    tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(cache_path)
+
+
+def read_filter_cache(cache_path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return unavailable_filter_payload(
+            "Filter switch service has not written a state yet.",
+            include_timestamp=False,
+        )
+    except json.JSONDecodeError:
+        return unavailable_filter_payload(
+            "Filter switch cache is not valid JSON.",
+            include_timestamp=False,
+        )
+
+    if not isinstance(payload, dict):
+        return unavailable_filter_payload(
+            "Filter switch cache is not a JSON object.",
+            include_timestamp=False,
+        )
+    return payload
+
+
+def filter_status_from_cache(project_root: Path) -> dict[str, object]:
+    cache_path = filter_cache_path_from_env(project_root)
+    payload = read_filter_cache(cache_path)
+    payload["cache_path"] = str(cache_path)
+
+    timestamp = payload.get("timestamp_unix")
+    if isinstance(timestamp, (int, float)):
+        stale_seconds = env_float(
+            "TINY_FILM_FILTER_STALE_SECONDS", DEFAULT_STALE_SECONDS
+        )
+        payload["age_seconds"] = round(max(0.0, time.time() - float(timestamp)), 1)
+        payload["stale"] = payload["age_seconds"] > stale_seconds
+    else:
+        payload["age_seconds"] = None
+        payload["stale"] = True
+
+    return payload

--- a/src/tiny-film-cam/filter_switch_test.py
+++ b/src/tiny-film-cam/filter_switch_test.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import time
+
+from filter_switch import (
+    DEFAULT_LEFT_PIN,
+    DEFAULT_RIGHT_PIN,
+    build_filter_state,
+    env_int,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read and print the three-position filter switch GPIO state."
+    )
+    parser.add_argument(
+        "--left-pin",
+        type=int,
+        default=env_int("TINY_FILM_FILTER_LEFT_PIN", DEFAULT_LEFT_PIN),
+    )
+    parser.add_argument(
+        "--right-pin",
+        type=int,
+        default=env_int("TINY_FILM_FILTER_RIGHT_PIN", DEFAULT_RIGHT_PIN),
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Print one reading instead of watching for changes.",
+    )
+    return parser.parse_args()
+
+
+def level(grounded: bool) -> str:
+    return "LOW" if grounded else "HIGH"
+
+
+def format_state(payload: dict[str, object]) -> str:
+    return (
+        f"position={payload['position']:<7} "
+        f"selection={str(payload['selection']):<17} "
+        f"GPIO{payload['left_pin']}={level(bool(payload['left_grounded']))} "
+        f"GPIO{payload['right_pin']}={level(bool(payload['right_grounded']))}"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        from gpiozero import Button
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing gpiozero. On the Raspberry Pi, install it with: "
+            "sudo apt install -y python3-gpiozero"
+        ) from exc
+
+    print("Stop tiny-film-filter.service before running this direct GPIO test.")
+    print("Move the slider through all three positions; press Ctrl+C to finish.")
+
+    try:
+        left_input = Button(args.left_pin, pull_up=True)
+        right_input = Button(args.right_pin, pull_up=True)
+    except Exception as exc:
+        raise SystemExit(
+            "Could not open the GPIO pins. Check wiring and stop the filter service."
+        ) from exc
+
+    previous: tuple[bool, bool] | None = None
+    try:
+        while True:
+            contacts = (left_input.is_pressed, right_input.is_pressed)
+            if contacts != previous:
+                payload = build_filter_state(
+                    left_grounded=contacts[0],
+                    right_grounded=contacts[1],
+                    left_pin=args.left_pin,
+                    right_pin=args.right_pin,
+                )
+                print(format_state(payload), flush=True)
+                previous = contacts
+            if args.once:
+                break
+            time.sleep(0.05)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        left_input.close()
+        right_input.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_filter_switch.py
+++ b/tests/test_filter_switch.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import threading
+import time
+import unittest
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "tiny-film-cam"
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SOURCE_ROOT / filename)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+filter_switch = load_module("filter_switch", "filter_switch.py")
+filter_daemon = load_module("tiny_film_filter_daemon", "filter_daemon.py")
+
+
+class FilterSwitchTest(unittest.TestCase):
+    def test_contact_truth_table(self) -> None:
+        self.assertEqual(filter_switch.position_from_contacts(True, False), "left")
+        self.assertEqual(filter_switch.position_from_contacts(False, False), "center")
+        self.assertEqual(filter_switch.position_from_contacts(False, True), "right")
+        self.assertIsNone(filter_switch.position_from_contacts(True, True))
+
+    def test_default_selections_match_camera_labels(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            selections = filter_switch.position_selections_from_env()
+
+        self.assertEqual(
+            selections,
+            {
+                "left": "black_and_white",
+                "center": "current",
+                "right": "cold",
+            },
+        )
+
+    def test_position_selections_are_configurable(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "TINY_FILM_FILTER_LEFT": "cold",
+                "TINY_FILM_FILTER_CENTER": "current",
+                "TINY_FILM_FILTER_RIGHT": "black_and_white",
+            },
+            clear=True,
+        ):
+            payload = filter_switch.build_filter_state(
+                left_grounded=True,
+                right_grounded=False,
+            )
+
+        self.assertEqual(payload["position"], "left")
+        self.assertEqual(payload["selection"], "cold")
+
+    def test_both_grounded_is_an_invalid_state(self) -> None:
+        payload = filter_switch.build_filter_state(
+            left_grounded=True,
+            right_grounded=True,
+        )
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["position"], "invalid")
+        self.assertIsNone(payload["selection"])
+
+    def test_cache_round_trip_and_status(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            cache_path = project_root / "data" / "filter-state.json"
+            payload = filter_switch.build_filter_state(
+                left_grounded=False,
+                right_grounded=False,
+            )
+            filter_switch.write_filter_cache(cache_path, payload)
+
+            status = filter_switch.filter_status_from_cache(project_root)
+
+        self.assertTrue(status["ok"])
+        self.assertEqual(status["position"], "center")
+        self.assertEqual(status["selection"], "current")
+        self.assertFalse(status["stale"])
+
+    def test_stale_and_missing_cache_statuses(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            cache_path = project_root / "data" / "filter-state.json"
+            cache_path.parent.mkdir(parents=True)
+            cache_path.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "timestamp_unix": time.time() - 60,
+                        "position": "right",
+                        "selection": "cold",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stale = filter_switch.filter_status_from_cache(project_root)
+            cache_path.unlink()
+            missing = filter_switch.filter_status_from_cache(project_root)
+
+        self.assertTrue(stale["stale"])
+        self.assertFalse(missing["ok"])
+        self.assertTrue(missing["stale"])
+
+    def test_monitor_debounces_and_emits_heartbeats(self) -> None:
+        readings = iter(
+            [
+                (False, False),
+                (True, False),
+                (False, False),
+                (True, False),
+                (True, False),
+                (True, False),
+                (True, False),
+            ]
+        )
+        last_reading = (True, False)
+
+        def read_contacts() -> tuple[bool, bool]:
+            nonlocal last_reading
+            try:
+                last_reading = next(readings)
+            except StopIteration:
+                pass
+            return last_reading
+
+        writes: list[tuple[bool, bool]] = []
+        stop_event = threading.Event()
+
+        def write_state(left: bool, right: bool) -> None:
+            writes.append((left, right))
+            if len(writes) == 2:
+                stop_event.set()
+
+        filter_daemon.monitor_contacts(
+            read_contacts=read_contacts,
+            write_state=write_state,
+            stop_event=stop_event,
+            poll_seconds=0.01,
+            debounce_seconds=0.015,
+            heartbeat_seconds=0.03,
+        )
+
+        self.assertEqual(writes, [(True, False), (True, False)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add an SS23D32 GPIO reader for BCM 27/22 with internal pull-ups
- add a live hardware test command and simulated-state mode
- debounce the selector in a dedicated service and cache its current selection
- install, restart, configure, and document the new service
- cover the contact truth table, cache behavior, configuration, and heartbeat

## Why

The web and physical-shutter processes need one consistent filter selection without competing for GPIO ownership. The dedicated service follows the existing battery-cache pattern and requires no external resistors.

## Validation

- `ruff check src/tiny-film-cam/filter_switch.py src/tiny-film-cam/filter_daemon.py src/tiny-film-cam/filter_switch_test.py tests/test_filter_switch.py`
- `bash -n scripts/run_filter_switch.sh scripts/install_service.sh scripts/restart_services.sh`
- `python3 -m unittest discover -s tests` (43 tests)
- simulated centre-state daemon and rendered service installer smoke tests
