### PR TITLE
Add separate photo and video buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,11 +29,13 @@ TINY_FILM_BATTERY_CALIBRATION=26868
 TINY_FILM_BATTERY_CURRENT_LSB_MA=0.1524
 TINY_FILM_BATTERY_POWER_LSB_W=0.003048
 
-# BCM GPIO pin for the physical shutter button.
-# Default wiring: button between BCM GPIO 17, physical pin 11, and GND.
-TINY_FILM_BUTTON_PIN=17
+# BCM GPIO pins for the separate physical photo and video buttons.
+# Default wiring: photo between GPIO 17 (physical pin 11) and GND; video
+# between GPIO 23 (physical pin 16) and GND.
+TINY_FILM_PHOTO_BUTTON_PIN=17
+TINY_FILM_VIDEO_BUTTON_PIN=23
 
-# Most simple Pi buttons connect GPIO to GND when pressed, so keep pull-up on.
+# Both buttons connect GPIO to GND when pressed, so keep pull-up on.
 TINY_FILM_BUTTON_PULL_UP=1
 TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ phone-friendly local gallery—without sending your photos to the cloud.
 
 ## What it does
 
-- Tap the physical shutter for a photo; hold it for a short video.
+- Use dedicated physical buttons for photos and short video clips.
 - Choose Black & white, Current, or Cold with a three-position hardware switch.
 - Capture, browse, download, and delete photos from a phone on the same Wi-Fi.
 - Monitor the Waveshare UPS battery from the web interface.
@@ -22,7 +22,7 @@ phone-friendly local gallery—without sending your photos to the cloud.
 - Raspberry Pi Zero 2 W
 - Raspberry Pi Camera Module 3
 - Waveshare UPS HAT (C)
-- Momentary shutter button
+- Two momentary buttons (photo and video)
 - Optional passive buzzer and SS23D32 three-position switch
 - 3D-printed enclosure from [`assets/`](assets/README.md)
 

--- a/docs/bom.md
+++ b/docs/bom.md
@@ -5,5 +5,6 @@
 - Raspberry Pi Camera Cable (Standard to Mini, 200mm)
 - MicroSD Card (A1, 32GB)
 - Uninterruptible Power Supply UPS HAT For Raspberry Pi Zero, Stable 5V Power Output
+- 2 × momentary tactile push buttons (one photo, one video)
 - [Passive Buzzer Module (DC 3.3V/5V)](http://shopee.sg/Passive-Buzzer-Module-DC-3.3V-5V-i.199330107.27956752948)
 - [3-Position 2P2T DPDT Panel Mount Slide Switch (SS23D32)](https://shopee.sg/10-x-DC-0.5A-50V-3-Position-2P2T-DPDT-Panel-Mount-Slide-Switch-SS23D32-i.1413766173.51250063839)

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -25,8 +25,8 @@ and **GND**.
 
 ## Wiring
 
-Avoid BCM GPIO 17 (shutter button) and BCM GPIO 2/3 (UPS HAT I2C). Use
-**BCM GPIO 18** (physical pin 12):
+Avoid BCM GPIO 17 (photo button), BCM GPIO 23 (video button), and BCM GPIO 2/3
+(UPS HAT I2C). Use **BCM GPIO 18** (physical pin 12):
 
 ```
 Buzzer VCC ──→ 3V3          (physical pin 1 or 17)

--- a/docs/filter-switch-plan.md
+++ b/docs/filter-switch-plan.md
@@ -44,8 +44,8 @@ pull-up resistors; the switch needs no 3.3 V or 5 V connection.
 | outer B | BCM GPIO 22, physical pin 15 |
 | second row, if present | leave disconnected |
 
-These pins avoid the existing shutter (BCM 17), buzzer (BCM 18), and UPS I2C
-(BCM 2/3) connections.
+These pins avoid the photo button (BCM 17), video button (BCM 23), buzzer
+(BCM 18), and UPS I2C (BCM 2/3) connections.
 
 | GPIO 27 | GPIO 22 | Selection |
 | --- | --- | --- |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -35,9 +35,11 @@
    ```bash
    i2cdetect -y 1
    ```
-10. Wire the shutter button between BCM GPIO 17, physical pin 11, and any GND
-   pin. With the default `.env.example` settings, the Pi uses its internal
-   pull-up resistor.
+10. Wire the photo button between BCM GPIO 17 (physical pin 11) and any GND
+    pin. Wire a separate video button between BCM GPIO 23 (physical pin 16) and
+    any GND pin. With the default `.env.example` settings, both use the Pi's
+    internal pull-up resistors; no external resistors are required. See
+    [shutter-button.md](shutter-button.md).
 11. Optionally wire the passive buzzer: VCC to 3V3, GND to GND, and I/O to
     BCM GPIO 18 (physical pin 12). The shutter daemon enables that pin by
     default — test with `python3 src/tiny-film-cam/buzzer.py`. See

--- a/docs/shutter-button.md
+++ b/docs/shutter-button.md
@@ -1,27 +1,35 @@
-# Shutter Button
+# Photo and Video Buttons
 
-Wire a 4-pin momentary tactile switch to trigger capture from a physical
-button. The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) listens for
-button presses and captures using the same settings as the web UI.
+Wire two 4-pin momentary tactile switches to give photo and video capture their
+own physical buttons. The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`)
+listens for both and captures using the same settings as the web UI.
 
-**Tap** the button for a photo. **Hold** it (1s by default) to record a short
-video clip instead.
+Press the **photo button** for a still image. Press the **video button** to
+record one video clip (10 seconds by default).
 
 ## Wiring
 
-A 4-pin tactile switch has two pairs of internally-connected pins. Only two
-connections are needed:
+A 4-pin tactile switch has two pairs of internally connected legs. For each
+button, use one leg from each side of the switch—not two legs from the same
+connected pair. Confirm the sides with a continuity tester if the switch body
+does not make them clear.
 
 ```
-Tactile switch pin 1 ──→ BCM GPIO 17 (physical pin 11)
-Tactile switch pin 2 ──→ GND         (physical pin 9, or any GND)
+Photo button, one side ──→ BCM GPIO 17 (physical pin 11)
+Photo button, other side ─→ GND        (physical pin 9, or any GND)
+
+Video button, one side ──→ BCM GPIO 23 (physical pin 16)
+Video button, other side ─→ GND        (physical pin 20, or any GND)
 ```
 
-The remaining two pins are left unconnected — they exist for mechanical
-stability on the PCB.
+The two buttons can share a GND connection. On each 4-pin switch, the unused
+two legs can be left unconnected; they duplicate the connected legs for
+mechanical stability.
 
-The daemon enables the Pi's internal pull-up resistor by default, so the GPIO
-reads HIGH at rest and goes LOW when the button is pressed.
+The daemon enables the Pi's internal pull-up resistor on both GPIOs by default,
+so each reads HIGH at rest and goes LOW when its button is pressed. No external
+resistors are required. Power the Pi off before changing the wiring, and do not
+connect either button to 5 V.
 
 ## Running
 
@@ -41,11 +49,14 @@ The service file is at `deploy/tiny-film-shutter.service`.
 
 | Setting | Env var | CLI flag | Default |
 |---------|---------|----------|---------|
-| GPIO pin | `TINY_FILM_BUTTON_PIN` | `--pin` | 17 |
-| Pull direction | `TINY_FILM_BUTTON_PULL_UP` | `--pull-up` / `--pull-down` | pull-up |
+| Photo GPIO pin | `TINY_FILM_PHOTO_BUTTON_PIN` | `--photo-pin` | 17 |
+| Video GPIO pin | `TINY_FILM_VIDEO_BUTTON_PIN` | `--video-pin` | 23 |
+| Pull direction (both) | `TINY_FILM_BUTTON_PULL_UP` | `--pull-up` / `--pull-down` | pull-up |
 | Debounce time | `TINY_FILM_BUTTON_BOUNCE_SECONDS` | `--bounce-time` | 0.15 s |
-| Hold-to-record | — | `--hold-time` | 1.0 s |
 | Video length | — | `--video-duration` | 10 s |
+
+`TINY_FILM_BUTTON_PIN` and `--pin` remain supported as legacy names for the
+photo pin. The new photo-specific setting takes precedence.
 
 All capture settings (quality, EV, rotation, AWB, etc.) are inherited from env
 vars or can be passed as CLI flags — run with `--help` for the full list.
@@ -55,10 +66,11 @@ For optional audible feedback from a passive buzzer module, see
 
 ## Notes
 
-- Pressing the button while a capture is already in progress is ignored (no
-  double-fires).
-- A hold long enough to start a video suppresses the photo that would otherwise
-  fire on release, so one long press yields exactly one clip.
+- Pressing either button while a photo or video is already in progress is
+  ignored (no double-fires or overlapping access to the camera).
+- Holding a button does not change its action or repeatedly trigger it: the
+  photo button takes one photo and the video button records one fixed-length
+  clip per press.
 - Photos and videos land in the same output directory as the web UI captures, so
   they appear in the gallery immediately.
 - If using pull-down wiring instead, connect the switch between GPIO and 3V3

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -44,6 +44,12 @@ def env_int(name: str, default: int) -> int:
     return int(value)
 
 
+def photo_button_pin_from_env() -> int:
+    """Read the photo button pin, preserving the original env var as a fallback."""
+    legacy_pin = env_int("TINY_FILM_BUTTON_PIN", 17)
+    return env_int("TINY_FILM_PHOTO_BUTTON_PIN", legacy_pin)
+
+
 def env_optional_int(name: str, default: int | None = None) -> int | None:
     """Read an optional int env var.
 
@@ -78,10 +84,23 @@ def parse_args() -> argparse.Namespace:
     capture_defaults = capture_settings_from_env(project_root)
     video_defaults = video_settings_from_env(project_root)
     parser = argparse.ArgumentParser(
-        description="Run the Tiny Film physical shutter button listener."
+        description="Run the Tiny Film physical photo and video button listener."
     )
     parser.add_argument("--project-root", type=Path, default=project_root)
-    parser.add_argument("--pin", type=int, default=env_int("TINY_FILM_BUTTON_PIN", 17))
+    parser.add_argument(
+        "--photo-pin",
+        "--pin",
+        dest="photo_pin",
+        type=int,
+        default=photo_button_pin_from_env(),
+        help="BCM GPIO pin for the photo button (default: 17).",
+    )
+    parser.add_argument(
+        "--video-pin",
+        type=int,
+        default=env_int("TINY_FILM_VIDEO_BUTTON_PIN", 23),
+        help="BCM GPIO pin for the video button (default: 23).",
+    )
     parser.set_defaults(pull_up=env_bool("TINY_FILM_BUTTON_PULL_UP", True))
     parser.add_argument("--pull-up", dest="pull_up", action="store_true")
     parser.add_argument("--pull-down", dest="pull_up", action="store_false")
@@ -142,16 +161,10 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--hold-time",
-        type=float,
-        default=1.0,
-        help="Seconds to hold the button before it records a video instead of a photo.",
-    )
-    parser.add_argument(
         "--video-duration",
         type=float,
         default=video_defaults.duration_seconds,
-        help="Length in seconds of a held-button video clip.",
+        help="Length in seconds of a video-button recording.",
     )
     parser.add_argument("--video-width", type=int, default=video_defaults.width)
     parser.add_argument("--video-height", type=int, default=video_defaults.height)
@@ -247,7 +260,6 @@ def main() -> None:
     output_dir = resolve_project_path(project_root, args.output_dir)
     capture_lock = threading.Lock()
     stop_event = threading.Event()
-    held_flag = threading.Event()
     buzzer_pin = None if args.no_buzzer else args.buzzer_pin
     buzzer = ShutterBuzzer(
         buzzer_pin,
@@ -308,13 +320,12 @@ def main() -> None:
             capture_lock.release()
 
     def record_clip() -> None:
-        held_flag.set()
         if not capture_lock.acquire(blocking=False):
-            LOGGER.info("Ignored button hold because a capture is already running")
+            LOGGER.info("Ignored video button because a capture is already running")
             return
 
         try:
-            LOGGER.info("Button held; recording %.1fs video", args.video_duration)
+            LOGGER.info("Video button pressed; recording %.1fs video", args.video_duration)
             buzzer.click()
             buzzer.video_start()
             settings = VideoSettings(
@@ -343,32 +354,33 @@ def main() -> None:
         finally:
             capture_lock.release()
 
-    def on_release() -> None:
-        # A long hold already triggered a video via when_held; skip the photo.
-        if held_flag.is_set():
-            held_flag.clear()
-            return
-        take_photo()
-
     signal.signal(signal.SIGINT, request_stop)
     signal.signal(signal.SIGTERM, request_stop)
 
-    button = Button(
-        args.pin,
+    photo_button = Button(
+        args.photo_pin,
         pull_up=args.pull_up,
         bounce_time=args.bounce_time if args.bounce_time > 0 else None,
-        hold_time=args.hold_time if args.hold_time > 0 else 1.0,
     )
-    button.when_held = record_clip
-    button.when_released = on_release
+    video_button = Button(
+        args.video_pin,
+        pull_up=args.pull_up,
+        bounce_time=args.bounce_time if args.bounce_time > 0 else None,
+    )
+    photo_button.when_pressed = take_photo
+    video_button.when_pressed = record_clip
 
     wiring = (
         "GPIO-to-GND with pull-up" if args.pull_up else "GPIO-to-3V3 with pull-down"
     )
-    LOGGER.info("Tiny Film shutter ready on BCM GPIO %s (%s)", args.pin, wiring)
     LOGGER.info(
-        "Tap to photograph; hold %.1fs to record a %.1fs video",
-        args.hold_time,
+        "Tiny Film buttons ready: photo on BCM GPIO %s, video on BCM GPIO %s (%s)",
+        args.photo_pin,
+        args.video_pin,
+        wiring,
+    )
+    LOGGER.info(
+        "Press photo to capture a still; press video to record a %.1fs clip",
         args.video_duration,
     )
     LOGGER.info("Captures will be saved under %s", output_dir)
@@ -390,7 +402,8 @@ def main() -> None:
         while not stop_event.wait(1.0):
             pass
     finally:
-        button.close()
+        photo_button.close()
+        video_button.close()
         buzzer.close()
 
 

--- a/tests/test_shutter_daemon.py
+++ b/tests/test_shutter_daemon.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "tiny-film-cam"
+SHUTTER_DAEMON_PATH = SOURCE_ROOT / "shutter_daemon.py"
+
+
+def load_shutter_daemon():
+    source_root = str(SOURCE_ROOT)
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+    spec = importlib.util.spec_from_file_location(
+        "tiny_film_shutter_daemon", SHUTTER_DAEMON_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load shutter daemon from {SHUTTER_DAEMON_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+shutter_daemon = load_shutter_daemon()
+
+
+class FakeButton:
+    instances: list["FakeButton"] = []
+
+    def __init__(self, pin: int, **kwargs: object) -> None:
+        self.pin = pin
+        self.kwargs = kwargs
+        self.when_pressed = None
+        self.closed = False
+        self.instances.append(self)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class StopImmediatelyEvent:
+    def set(self) -> None:
+        return None
+
+    def wait(self, timeout: float) -> bool:
+        return True
+
+
+class ShutterDaemonTest(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeButton.instances.clear()
+
+    def test_default_and_configured_button_pins(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(sys, "argv", ["shutter_daemon.py"]),
+        ):
+            defaults = shutter_daemon.parse_args()
+
+        self.assertEqual(defaults.photo_pin, 17)
+        self.assertEqual(defaults.video_pin, 23)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "TINY_FILM_BUTTON_PIN": "5",
+                    "TINY_FILM_PHOTO_BUTTON_PIN": "6",
+                    "TINY_FILM_VIDEO_BUTTON_PIN": "24",
+                },
+                clear=True,
+            ),
+            patch.object(sys, "argv", ["shutter_daemon.py"]),
+        ):
+            configured = shutter_daemon.parse_args()
+
+        self.assertEqual(configured.photo_pin, 6)
+        self.assertEqual(configured.video_pin, 24)
+
+    def test_legacy_button_pin_still_configures_photo_button(self) -> None:
+        with (
+            patch.dict(os.environ, {"TINY_FILM_BUTTON_PIN": "5"}, clear=True),
+            patch.object(sys, "argv", ["shutter_daemon.py"]),
+        ):
+            args = shutter_daemon.parse_args()
+
+        self.assertEqual(args.photo_pin, 5)
+        self.assertEqual(args.video_pin, 23)
+
+    def test_each_button_registers_its_own_capture_action(self) -> None:
+        fake_gpiozero = types.ModuleType("gpiozero")
+        fake_gpiozero.Button = FakeButton
+        buzzer = MagicMock()
+        buzzer.enabled = False
+        photo_path = Path("photo.jpg")
+        video_path = Path("video.mp4")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.dict(sys.modules, {"gpiozero": fake_gpiozero}),
+            patch.object(sys, "argv", ["shutter_daemon.py", "--no-buzzer"]),
+            patch.object(shutter_daemon, "ShutterBuzzer", return_value=buzzer),
+            patch.object(
+                shutter_daemon, "capture_photos", return_value=[photo_path]
+            ) as capture_photos,
+            patch.object(
+                shutter_daemon, "record_video", return_value=video_path
+            ) as record_video,
+            patch.object(
+                shutter_daemon,
+                "selected_photo_filter_from_cache",
+                return_value="current",
+            ),
+            patch.object(
+                shutter_daemon.threading,
+                "Event",
+                return_value=StopImmediatelyEvent(),
+            ),
+            patch.object(shutter_daemon.signal, "signal"),
+        ):
+            shutter_daemon.main()
+            self.assertEqual(
+                [button.pin for button in FakeButton.instances], [17, 23]
+            )
+            self.assertTrue(all(button.closed for button in FakeButton.instances))
+            self.assertNotIn("hold_time", FakeButton.instances[0].kwargs)
+            self.assertNotIn("hold_time", FakeButton.instances[1].kwargs)
+
+            photo_action = FakeButton.instances[0].when_pressed
+            video_action = FakeButton.instances[1].when_pressed
+            self.assertIsNotNone(photo_action)
+            self.assertIsNotNone(video_action)
+            photo_action()
+            video_action()
+
+            capture_photos.assert_called_once()
+            record_video.assert_called_once()
+            self.assertEqual(capture_photos.call_args.args[0].photo_filter, "current")
+            self.assertEqual(record_video.call_args.args[0].duration_seconds, 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the tap/hold shutter gesture with dedicated photo and video buttons
- keep photo capture on BCM GPIO 17 and add video capture on BCM GPIO 23
- preserve the legacy photo-pin configuration while adding explicit photo/video settings
- document the two-button wiring, shared ground, internal pull-ups, and BOM change
- add daemon tests for default/configured pins and independent capture callbacks

## Why

Separate controls make photo and video capture unambiguous and remove the delay and interaction complexity of hold-to-record.

## User impact

Builders add a second momentary button between BCM GPIO 23 (physical pin 16) and ground. The existing BCM GPIO 17 photo-button wiring remains unchanged. No external resistors are required with the default pull-up configuration.

## Validation

- \`python3 -m unittest discover -s tests\` (54 tests)
- \`git diff --check\`
