### PR TITLE
Swap button pins and quiet capture buzzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,10 @@ TINY_FILM_BATTERY_CURRENT_LSB_MA=0.1524
 TINY_FILM_BATTERY_POWER_LSB_W=0.003048
 
 # BCM GPIO pins for the separate physical photo and video buttons.
-# Default wiring: photo between GPIO 17 (physical pin 11) and GND; video
-# between GPIO 5 (physical pin 29) and the adjacent GND (physical pin 30).
-TINY_FILM_PHOTO_BUTTON_PIN=17
-TINY_FILM_VIDEO_BUTTON_PIN=5
+# Default wiring: photo between GPIO 5 (physical pin 29) and GND; video
+# between GPIO 17 (physical pin 11) and GND.
+TINY_FILM_PHOTO_BUTTON_PIN=5
+TINY_FILM_VIDEO_BUTTON_PIN=17
 
 # Both buttons connect GPIO to GND when pressed, so keep pull-up on.
 TINY_FILM_BUTTON_PULL_UP=1
@@ -50,8 +50,8 @@ TINY_FILM_BUZZER_PHOTO_SOUND=click
 # Loudness for ready/video/error cues (0.0–1.0). Uses burst density — duty
 # cycle alone does nothing on transistor modules.
 TINY_FILM_BUZZER_VOLUME=0.90
-# Softer loudness for the per-capture cue (plays right after the frame).
-TINY_FILM_BUZZER_PHOTO_VOLUME=0.30
+# Quiet loudness for the per-capture cue (plays right after the frame).
+TINY_FILM_BUZZER_PHOTO_VOLUME=0.10
 
 TINY_FILM_OUTPUT_DIR=data/captures
 # Optional still-image dimensions in pixels. Leave both blank to use the

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -25,7 +25,7 @@ and **GND**.
 
 ## Wiring
 
-Avoid BCM GPIO 17 (photo button), BCM GPIO 5 (video button), and BCM GPIO 2/3
+Avoid BCM GPIO 5 (photo button), BCM GPIO 17 (video button), and BCM GPIO 2/3
 (UPS HAT I2C). Use **BCM GPIO 18** (physical pin 12):
 
 ```

--- a/docs/filter-switch-plan.md
+++ b/docs/filter-switch-plan.md
@@ -44,7 +44,7 @@ pull-up resistors; the switch needs no 3.3 V or 5 V connection.
 | outer B | BCM GPIO 20, physical pin 38 |
 | second row, if present | leave disconnected |
 
-These pins avoid the photo button (BCM 17), video button (BCM 5), buzzer
+These pins avoid the photo button (BCM 5), video button (BCM 17), buzzer
 (BCM 18), and UPS I2C (BCM 2/3) connections.
 
 | GPIO 26 | GPIO 20 | Selection |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -35,9 +35,9 @@
    ```bash
    i2cdetect -y 1
    ```
-10. Wire the photo button between BCM GPIO 17 (physical pin 11) and any GND
-    pin. Wire a separate video button between BCM GPIO 5 (physical pin 29) and
-    the adjacent GND (physical pin 30). With the default `.env.example`
+10. Wire the photo button between BCM GPIO 5 (physical pin 29) and the adjacent
+    GND (physical pin 30). Wire a separate video button between BCM GPIO 17
+    (physical pin 11) and any GND pin. With the default `.env.example`
     settings, both use the Pi's internal pull-up resistors; no external
     resistors are required. See
     [shutter-button.md](shutter-button.md).

--- a/docs/shutter-button.md
+++ b/docs/shutter-button.md
@@ -15,11 +15,11 @@ connected pair. Confirm the sides with a continuity tester if the switch body
 does not make them clear.
 
 ```
-Photo button, one side ──→ BCM GPIO 17 (physical pin 11)
-Photo button, other side ─→ GND        (physical pin 9, or any GND)
+Photo button, one side ──→ BCM GPIO 5 (physical pin 29)
+Photo button, other side ─→ GND       (physical pin 30, or any GND)
 
-Video button, one side ──→ BCM GPIO 5 (physical pin 29)
-Video button, other side ─→ GND       (physical pin 30, or any GND)
+Video button, one side ──→ BCM GPIO 17 (physical pin 11)
+Video button, other side ─→ GND        (physical pin 9, or any GND)
 ```
 
 The two buttons can share a GND connection. On each 4-pin switch, the unused
@@ -49,14 +49,22 @@ The service file is at `deploy/tiny-film-shutter.service`.
 
 | Setting | Env var | CLI flag | Default |
 |---------|---------|----------|---------|
-| Photo GPIO pin | `TINY_FILM_PHOTO_BUTTON_PIN` | `--photo-pin` | 17 |
-| Video GPIO pin | `TINY_FILM_VIDEO_BUTTON_PIN` | `--video-pin` | 5 |
+| Photo GPIO pin | `TINY_FILM_PHOTO_BUTTON_PIN` | `--photo-pin` | 5 |
+| Video GPIO pin | `TINY_FILM_VIDEO_BUTTON_PIN` | `--video-pin` | 17 |
 | Pull direction (both) | `TINY_FILM_BUTTON_PULL_UP` | `--pull-up` / `--pull-down` | pull-up |
 | Debounce time | `TINY_FILM_BUTTON_BOUNCE_SECONDS` | `--bounce-time` | 0.15 s |
 | Video length | — | `--video-duration` | 10 s |
 
 `TINY_FILM_BUTTON_PIN` and `--pin` remain supported as legacy names for the
 photo pin. The new photo-specific setting takes precedence.
+
+When upgrading an existing installation that still has
+`TINY_FILM_BUTTON_PIN=17`, replace it with the explicit current mapping:
+
+```dotenv
+TINY_FILM_PHOTO_BUTTON_PIN=5
+TINY_FILM_VIDEO_BUTTON_PIN=17
+```
 
 All capture settings (quality, EV, rotation, AWB, etc.) are inherited from env
 vars or can be passed as CLI flags — run with `--help` for the full list.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -6,8 +6,8 @@ Power off and unplug the Raspberry Pi before changing any wiring.
 
 | Control | First side | Other side |
 | --- | --- | --- |
-| Photo button | BCM GPIO 17 (physical pin 11) | GND (physical pin 9) |
-| Video button | BCM GPIO 5 (physical pin 29) | GND (physical pin 30) |
+| Photo button | BCM GPIO 5 (physical pin 29) | GND (physical pin 30) |
+| Video button | BCM GPIO 17 (physical pin 11) | GND (physical pin 9) |
 
 The buttons can share any GND pin. For a 4-pin tactile button, connect one leg
 from each side of the button; the two legs on each side are already connected

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -46,7 +46,7 @@ def env_int(name: str, default: int) -> int:
 
 def photo_button_pin_from_env() -> int:
     """Read the photo button pin, preserving the original env var as a fallback."""
-    legacy_pin = env_int("TINY_FILM_BUTTON_PIN", 17)
+    legacy_pin = env_int("TINY_FILM_BUTTON_PIN", 5)
     return env_int("TINY_FILM_PHOTO_BUTTON_PIN", legacy_pin)
 
 
@@ -93,13 +93,13 @@ def parse_args() -> argparse.Namespace:
         dest="photo_pin",
         type=int,
         default=photo_button_pin_from_env(),
-        help="BCM GPIO pin for the photo button (default: 17).",
+        help="BCM GPIO pin for the photo button (default: 5).",
     )
     parser.add_argument(
         "--video-pin",
         type=int,
-        default=env_int("TINY_FILM_VIDEO_BUTTON_PIN", 5),
-        help="BCM GPIO pin for the video button (default: 5).",
+        default=env_int("TINY_FILM_VIDEO_BUTTON_PIN", 17),
+        help="BCM GPIO pin for the video button (default: 17).",
     )
     parser.set_defaults(pull_up=env_bool("TINY_FILM_BUTTON_PULL_UP", True))
     parser.add_argument("--pull-up", dest="pull_up", action="store_true")

--- a/tests/test_shutter_daemon.py
+++ b/tests/test_shutter_daemon.py
@@ -64,8 +64,8 @@ class ShutterDaemonTest(unittest.TestCase):
         ):
             defaults = shutter_daemon.parse_args()
 
-        self.assertEqual(defaults.photo_pin, 17)
-        self.assertEqual(defaults.video_pin, 5)
+        self.assertEqual(defaults.photo_pin, 5)
+        self.assertEqual(defaults.video_pin, 17)
 
         with (
             patch.dict(
@@ -86,13 +86,13 @@ class ShutterDaemonTest(unittest.TestCase):
 
     def test_legacy_button_pin_still_configures_photo_button(self) -> None:
         with (
-            patch.dict(os.environ, {"TINY_FILM_BUTTON_PIN": "5"}, clear=True),
+            patch.dict(os.environ, {"TINY_FILM_BUTTON_PIN": "6"}, clear=True),
             patch.object(sys, "argv", ["shutter_daemon.py"]),
         ):
             args = shutter_daemon.parse_args()
 
-        self.assertEqual(args.photo_pin, 5)
-        self.assertEqual(args.video_pin, 5)
+        self.assertEqual(args.photo_pin, 6)
+        self.assertEqual(args.video_pin, 17)
 
     def test_each_button_registers_its_own_capture_action(self) -> None:
         fake_gpiozero = types.ModuleType("gpiozero")
@@ -127,7 +127,7 @@ class ShutterDaemonTest(unittest.TestCase):
         ):
             shutter_daemon.main()
             self.assertEqual(
-                [button.pin for button in FakeButton.instances], [17, 5]
+                [button.pin for button in FakeButton.instances], [5, 17]
             )
             self.assertTrue(all(button.closed for button in FakeButton.instances))
             self.assertNotIn("hold_time", FakeButton.instances[0].kwargs)


### PR DESCRIPTION
## Summary

- make BCM GPIO 5 the default photo button and BCM GPIO 17 the default video button
- update the example environment, wiring/setup guidance, and migration documentation for the swapped controls
- lower the example photo-capture buzzer volume from 0.30 to 0.10

## Why

The physical button connected to BCM GPIO 5 is now the photo shutter. Existing defaults and documentation assigned that button to video, so runtime behavior, example configuration, and wiring guidance all needed to move together. The capture cue was also too loud on the target passive buzzer.

## Validation

- `python3 tests/test_shutter_daemon.py`
- `python3 -m unittest discover -s tests` (55 tests)
- `git diff --check`
