### PR TITLE
Delay startup buzzer until system settles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
+# Wait for systemd boot to finish, then allow final disk activity to settle
+# before playing the ready cue.
+TINY_FILM_BUZZER_READY_DELAY_SECONDS=5
 # Photo cue: click (default), minimal, gentle, shutter, or sparkle.
 TINY_FILM_BUZZER_PHOTO_SOUND=click
 # Loudness for ready/video/error cues (0.0–1.0). Uses burst density — duty

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,7 +5,7 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **minimal** | Shutter daemon initialized successfully (default ready cue) |
+| **minimal** | System startup finished and the settle delay elapsed (default ready cue) |
 | **click** | Frame captured (default; shorter/softer tick than minimal) |
 | **gentle** | Frame-captured option with a descending two-note cue |
 | **shutter** | Frame-captured option with two dry mechanical-style taps |
@@ -83,12 +83,15 @@ python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 ## Using it with the shutter
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
-With the defaults, `minimal` at volume `0.90` plays once when the shutter
-daemon is ready. A softer `click` at volume `0.30` plays immediately after the
-camera returns a frame, before rotation, JPEG encoding, and disk saving.
+With the defaults, the daemon waits for systemd to finish booting, allows five
+more seconds for startup disk activity to settle, and then plays `minimal` once
+at volume `0.90`. When the daemon is run outside systemd, only the five-second
+settle delay applies. A softer `click` at volume `0.30` plays immediately after
+the camera returns a frame, before rotation, JPEG encoding, and disk saving.
 If an existing `.env` overrides older buzzer defaults, set:
 
 ```bash
+TINY_FILM_BUZZER_READY_DELAY_SECONDS=5
 TINY_FILM_BUZZER_PHOTO_SOUND=click
 TINY_FILM_BUZZER_VOLUME=0.90
 TINY_FILM_BUZZER_PHOTO_VOLUME=0.30
@@ -122,6 +125,7 @@ python3 src/tiny-film-cam/shutter_daemon.py --no-buzzer
 |---------|---------|----------|---------|
 | Buzzer pin | `TINY_FILM_BUZZER_PIN` | `--buzzer-pin` / `--no-buzzer` | `18` (blank = disabled) |
 | Buzzer type | `TINY_FILM_BUZZER_ACTIVE` | `--buzzer-active` / `--buzzer-passive` | passive |
+| Ready settle delay | `TINY_FILM_BUZZER_READY_DELAY_SECONDS` | `--buzzer-ready-delay` | `5` seconds after boot finishes |
 | Photo sound | `TINY_FILM_BUZZER_PHOTO_SOUND` | `--buzzer-photo-sound` | `click` |
 | Ready/video volume | `TINY_FILM_BUZZER_VOLUME` | `--buzzer-volume` | `0.90` |
 | Photo volume | `TINY_FILM_BUZZER_PHOTO_VOLUME` | `--buzzer-photo-volume` | `0.30` |

--- a/src/tiny-film-cam/buzzer.py
+++ b/src/tiny-film-cam/buzzer.py
@@ -147,7 +147,7 @@ class ShutterBuzzer:
         return self._device is not None
 
     def ready(self) -> None:
-        """Confirmation that the shutter daemon initialized successfully."""
+        """Play the system-ready confirmation cue."""
         self.play(READY_SOUND, volume=self._volume)
 
     def click(self) -> None:

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import signal
+import subprocess
 import threading
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from photo_filters import selected_photo_filter_from_cache
 
 
 LOGGER = logging.getLogger("tiny_film.shutter")
+DEFAULT_BUZZER_READY_DELAY_SECONDS = 5.0
+SYSTEMD_RUNTIME_PATH = Path("/run/systemd/system")
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -77,6 +80,84 @@ def parse_exposure_brackets(value: str) -> tuple[float, ...]:
 
 def default_project_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def wait_for_system_startup(stop_event: threading.Event) -> bool:
+    """Wait for systemd to finish booting, if this host uses systemd.
+
+    Returns ``False`` only when shutdown was requested while waiting. If
+    systemd is unavailable, the caller can still use its normal settle delay.
+    """
+    if stop_event.is_set():
+        return False
+    if not SYSTEMD_RUNTIME_PATH.is_dir():
+        return True
+
+    LOGGER.info("Waiting for system startup to finish before the ready cue")
+    try:
+        process = subprocess.Popen(
+            ("systemctl", "is-system-running", "--wait"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        LOGGER.warning(
+            "Could not wait for system startup (%s); using the ready delay only",
+            exc,
+        )
+        return not stop_event.is_set()
+
+    while process.poll() is None:
+        if stop_event.wait(0.25):
+            try:
+                process.terminate()
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                try:
+                    process.kill()
+                except OSError:
+                    pass
+                process.wait()
+            return False
+
+    stdout, stderr = process.communicate()
+    state = stdout.strip()
+    if state in {"running", "degraded"}:
+        LOGGER.info("System startup finished with state %s", state)
+    else:
+        detail = state or stderr.strip() or f"exit status {process.returncode}"
+        LOGGER.warning(
+            "Could not confirm system startup state (%s); using the ready delay",
+            detail,
+        )
+    return not stop_event.is_set()
+
+
+def play_ready_when_settled(
+    *,
+    buzzer: ShutterBuzzer,
+    stop_event: threading.Event,
+    delay_seconds: float,
+) -> None:
+    """Play the ready cue after boot completion and a final settle delay."""
+    if not wait_for_system_startup(stop_event):
+        return
+
+    delay_seconds = max(0.0, delay_seconds)
+    if delay_seconds:
+        LOGGER.info(
+            "Waiting %.1f seconds for startup activity to settle",
+            delay_seconds,
+        )
+    if stop_event.wait(delay_seconds):
+        return
+
+    LOGGER.info("Startup settled; playing the ready cue")
+    buzzer.ready()
 
 
 def parse_args() -> argparse.Namespace:
@@ -158,6 +239,18 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Photo capture cue: click, minimal, gentle, shutter, or sparkle "
             f"(default: {DEFAULT_PHOTO_SOUND})."
+        ),
+    )
+    parser.add_argument(
+        "--buzzer-ready-delay",
+        type=float,
+        default=env_float(
+            "TINY_FILM_BUZZER_READY_DELAY_SECONDS",
+            DEFAULT_BUZZER_READY_DELAY_SECONDS,
+        ),
+        help=(
+            "Seconds to wait after system startup finishes before the ready cue "
+            f"(default: {DEFAULT_BUZZER_READY_DELAY_SECONDS})."
         ),
     )
     parser.add_argument(
@@ -260,6 +353,7 @@ def main() -> None:
     output_dir = resolve_project_path(project_root, args.output_dir)
     capture_lock = threading.Lock()
     stop_event = threading.Event()
+    ready_thread: threading.Thread | None = None
     buzzer_pin = None if args.no_buzzer else args.buzzer_pin
     buzzer = ShutterBuzzer(
         buzzer_pin,
@@ -396,7 +490,17 @@ def main() -> None:
             args.buzzer_photo_sound,
             args.buzzer_photo_volume,
         )
-        buzzer.ready()
+        ready_thread = threading.Thread(
+            target=play_ready_when_settled,
+            kwargs={
+                "buzzer": buzzer,
+                "stop_event": stop_event,
+                "delay_seconds": args.buzzer_ready_delay,
+            },
+            name="tiny-film-ready-cue",
+            daemon=True,
+        )
+        ready_thread.start()
     elif args.no_buzzer or buzzer_pin is None:
         LOGGER.info("Buzzer feedback disabled")
 
@@ -404,6 +508,9 @@ def main() -> None:
         while not stop_event.wait(1.0):
             pass
     finally:
+        stop_event.set()
+        if ready_thread is not None:
+            ready_thread.join(timeout=2.0)
         photo_button.close()
         video_button.close()
         buzzer.close()

--- a/tests/test_shutter_daemon.py
+++ b/tests/test_shutter_daemon.py
@@ -66,6 +66,10 @@ class ShutterDaemonTest(unittest.TestCase):
 
         self.assertEqual(defaults.photo_pin, 5)
         self.assertEqual(defaults.video_pin, 17)
+        self.assertEqual(
+            defaults.buzzer_ready_delay,
+            shutter_daemon.DEFAULT_BUZZER_READY_DELAY_SECONDS,
+        )
 
         with (
             patch.dict(
@@ -74,6 +78,7 @@ class ShutterDaemonTest(unittest.TestCase):
                     "TINY_FILM_BUTTON_PIN": "5",
                     "TINY_FILM_PHOTO_BUTTON_PIN": "6",
                     "TINY_FILM_VIDEO_BUTTON_PIN": "24",
+                    "TINY_FILM_BUZZER_READY_DELAY_SECONDS": "8.5",
                 },
                 clear=True,
             ),
@@ -83,6 +88,7 @@ class ShutterDaemonTest(unittest.TestCase):
 
         self.assertEqual(configured.photo_pin, 6)
         self.assertEqual(configured.video_pin, 24)
+        self.assertEqual(configured.buzzer_ready_delay, 8.5)
 
     def test_legacy_button_pin_still_configures_photo_button(self) -> None:
         with (
@@ -93,6 +99,92 @@ class ShutterDaemonTest(unittest.TestCase):
 
         self.assertEqual(args.photo_pin, 6)
         self.assertEqual(args.video_pin, 17)
+
+    def test_ready_cue_waits_for_boot_and_settle_delay(self) -> None:
+        buzzer = MagicMock()
+        stop_event = MagicMock()
+        stop_event.wait.return_value = False
+
+        with patch.object(
+            shutter_daemon,
+            "wait_for_system_startup",
+            return_value=True,
+        ) as wait_for_system_startup:
+            shutter_daemon.play_ready_when_settled(
+                buzzer=buzzer,
+                stop_event=stop_event,
+                delay_seconds=5.0,
+            )
+
+        wait_for_system_startup.assert_called_once_with(stop_event)
+        stop_event.wait.assert_called_once_with(5.0)
+        buzzer.ready.assert_called_once_with()
+
+    def test_ready_cue_is_cancelled_during_shutdown(self) -> None:
+        buzzer = MagicMock()
+        stop_event = MagicMock()
+        stop_event.wait.return_value = True
+
+        with patch.object(
+            shutter_daemon,
+            "wait_for_system_startup",
+            return_value=True,
+        ):
+            shutter_daemon.play_ready_when_settled(
+                buzzer=buzzer,
+                stop_event=stop_event,
+                delay_seconds=5.0,
+            )
+
+        buzzer.ready.assert_not_called()
+
+    def test_systemd_wait_returns_after_boot_finishes(self) -> None:
+        stop_event = MagicMock()
+        stop_event.wait.return_value = False
+        stop_event.is_set.return_value = False
+        process = MagicMock()
+        process.poll.side_effect = (None, 0)
+        process.communicate.return_value = ("running\n", "")
+
+        with (
+            patch.object(shutter_daemon, "SYSTEMD_RUNTIME_PATH") as runtime_path,
+            patch.object(
+                shutter_daemon.subprocess,
+                "Popen",
+                return_value=process,
+            ) as popen,
+        ):
+            runtime_path.is_dir.return_value = True
+            completed = shutter_daemon.wait_for_system_startup(stop_event)
+
+        self.assertTrue(completed)
+        popen.assert_called_once_with(
+            ("systemctl", "is-system-running", "--wait"),
+            stdout=shutter_daemon.subprocess.PIPE,
+            stderr=shutter_daemon.subprocess.PIPE,
+            text=True,
+        )
+
+    def test_systemd_wait_stops_during_shutdown(self) -> None:
+        stop_event = MagicMock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.return_value = True
+        process = MagicMock()
+        process.poll.return_value = None
+
+        with (
+            patch.object(shutter_daemon, "SYSTEMD_RUNTIME_PATH") as runtime_path,
+            patch.object(
+                shutter_daemon.subprocess,
+                "Popen",
+                return_value=process,
+            ),
+        ):
+            runtime_path.is_dir.return_value = True
+            completed = shutter_daemon.wait_for_system_startup(stop_event)
+
+        self.assertFalse(completed)
+        process.terminate.assert_called_once_with()
 
     def test_each_button_registers_its_own_capture_action(self) -> None:
         fake_gpiozero = types.ModuleType("gpiozero")


### PR DESCRIPTION
## Summary

- wait for systemd to report boot completion before playing the ready cue
- add a configurable five-second settling delay and cancel cleanly during shutdown
- document `TINY_FILM_BUZZER_READY_DELAY_SECONDS` and cover startup/shutdown behavior with tests

## Why

The buzzer fired as soon as the shutter daemon initialized, while other boot jobs and disk activity were still running. The cue now better represents that camera startup has settled.

## Validation

- `python3 -m unittest discover -s tests -v` (65 tests)
- `git diff --check`