### PR TITLE
Simplify photo mode panel

### DIFF
--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -415,17 +415,6 @@ def render_page() -> bytes:
             letter-spacing: 0.08em;
             text-transform: uppercase;
           }
-          .mode-copy strong {
-            font-size: 16px;
-          }
-          .mode-state {
-            color: var(--muted);
-            font-size: 11px;
-            line-height: 1.35;
-          }
-          .filter-summary.warning .mode-state {
-            color: var(--accent-dark);
-          }
           .mode-options {
             display: grid;
             gap: 8px;
@@ -722,12 +711,8 @@ def render_page() -> bytes:
               padding: 11px 12px;
             }
             .mode-copy {
-              gap: 1px;
-              grid-template-columns: auto 1fr;
-              column-gap: 8px;
+              display: block;
             }
-            .mode-copy .eyebrow,
-            .mode-copy .mode-state { grid-column: 1 / -1; }
             .mode-option {
               flex-direction: column;
               font-size: 10px;
@@ -786,8 +771,6 @@ def render_page() -> bytes:
             <div class="filter-summary warning" id="filter-summary" aria-live="polite">
               <div class="mode-copy">
                 <span class="eyebrow">Current photo mode</span>
-                <strong id="filter-active-label">Checking...</strong>
-                <span class="mode-state" id="filter-state">Checking mode</span>
               </div>
               <div class="mode-options" role="list" aria-label="Available photo modes">
                 <div class="mode-option" data-filter="black_and_white" role="listitem">
@@ -848,8 +831,6 @@ def render_page() -> bytes:
           const recordButton = document.getElementById("record-button");
           const recordButtonLabel = document.getElementById("record-button-label");
           const filterSummary = document.getElementById("filter-summary");
-          const filterActiveLabel = document.getElementById("filter-active-label");
-          const filterState = document.getElementById("filter-state");
           const modeOptions = Array.from(document.querySelectorAll(".mode-option"));
           let captureImages = [];
           let selectedCaptureIndex = 0;
@@ -1170,15 +1151,15 @@ def render_page() -> bytes:
             const label = activeFilter.label || "Normal";
             const activeFilterId = activeFilter.id || "normal";
             const warning = Boolean(details.using_fallback || details.stale || !details.ok);
-            const position = details.position || "unknown";
-            filterActiveLabel.textContent = label;
-            filterState.textContent = warning
-              ? `Fallback mode · switch ${position}`
-              : `Mode · ${position}`;
             filterSummary.className = warning ? "filter-summary warning" : "filter-summary";
-            filterSummary.title = warning
+            const summary = warning
               ? details.error || "Filter switch unavailable; using Normal"
               : `Current mode: ${label}`;
+            filterSummary.title = summary;
+            filterSummary.setAttribute(
+              "aria-label",
+              warning ? `Current photo mode: ${label}. ${summary}` : `Current photo mode: ${label}`,
+            );
             modeOptions.forEach((option) => {
               const active = option.dataset.filter === activeFilterId;
               option.classList.toggle("active", active);

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -36,6 +36,8 @@ class RenderPageTest(unittest.TestCase):
         self.assertIn('id="capture-button"', page)
         self.assertNotIn('id="preview-heading"', page)
         self.assertNotIn('id="capture-position"', page)
+        self.assertNotIn('id="filter-active-label"', page)
+        self.assertNotIn('id="filter-state"', page)
 
 
 class CaptureMediaServerTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- remove the duplicate active-mode label beneath Current photo mode
- remove the visible fallback and switch-position status line
- rely on the highlighted mode tile as the visual source of truth
- preserve fallback diagnostics in the panel tooltip and accessible label
- add regression coverage for the removed status elements

## Why

The selected mode tile already identifies the active mode. The additional active-mode and fallback rows repeated that information and made the panel taller, pushing the photo farther down on mobile.

## Validation

- `python3 -m unittest discover -s tests` (66 tests passed)
- mobile visual check at 393 x 852: mode panel reduced from 140px to 110px and the photo begins at 278px
