### PR TITLE
Remove batch photo saving controls

### DIFF
--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -33,7 +33,6 @@ IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
 VIDEO_SUFFIXES = {".mp4"}
 CAPTURE_SUFFIXES = IMAGE_SUFFIXES | VIDEO_SUFFIXES
 HOME_GALLERY_LIMIT = 50
-MAX_SELECTED_PHOTOS = 10
 
 
 def media_type_for(path: Path) -> str:
@@ -532,26 +531,6 @@ def render_page(page_name: str = "home") -> bytes:
             flex-wrap: wrap;
             gap: 10px;
           }
-          .selection-toolbar {
-            align-items: center;
-            background: rgba(255, 253, 248, 0.86);
-            border: 1px solid var(--line);
-            border-radius: 16px;
-            display: flex;
-            gap: 12px;
-            justify-content: space-between;
-            margin-bottom: 14px;
-            min-height: 58px;
-            padding: 9px 10px 9px 14px;
-          }
-          .selection-copy {
-            display: grid;
-            gap: 3px;
-          }
-          .selection-hint {
-            color: var(--muted);
-            font-size: 11px;
-          }
           .latest .section-heading {
             margin-bottom: 0;
           }
@@ -599,10 +578,6 @@ def render_page(page_name: str = "home") -> bytes:
           }
           .gallery-item.selected .gallery-thumb {
             border-color: var(--blue);
-          }
-          .gallery-item.photo-selected .gallery-thumb {
-            border-color: var(--accent);
-            box-shadow: inset 0 0 0 1px var(--accent);
           }
           .gallery-thumb img {
             display: block;
@@ -655,38 +630,6 @@ def render_page(page_name: str = "home") -> bytes:
             padding: 0 2px;
             text-overflow: ellipsis;
             white-space: nowrap;
-          }
-          .photo-select-button {
-            align-items: center;
-            appearance: none;
-            background: rgba(255, 255, 255, 0.9);
-            border: 2px solid var(--fg);
-            border-radius: 50%;
-            color: transparent;
-            cursor: pointer;
-            display: flex;
-            height: 30px;
-            justify-content: center;
-            padding: 0;
-            position: absolute;
-            right: 8px;
-            top: 8px;
-            width: 30px;
-            z-index: 2;
-          }
-          .photo-select-button[aria-pressed="true"] {
-            background: var(--accent);
-            border-color: #fff;
-            color: #fff;
-          }
-          .photo-select-button svg {
-            fill: none;
-            height: 17px;
-            stroke: currentColor;
-            stroke-linecap: round;
-            stroke-linejoin: round;
-            stroke-width: 2.5;
-            width: 17px;
           }
           .capture-info {
             display: grid;
@@ -742,7 +685,6 @@ def render_page(page_name: str = "home") -> bytes:
             color: var(--accent);
           }
           .gallery-preview:focus-visible,
-          .photo-select-button:focus-visible,
           .button:focus-visible,
           .icon-button:focus-visible {
             outline: 3px solid rgba(75, 120, 194, 0.4);
@@ -804,11 +746,6 @@ def render_page(page_name: str = "home") -> bytes:
               flex-direction: column;
             }
             .gallery-heading-actions { width: 100%; }
-            .selection-toolbar {
-              align-items: stretch;
-              flex-direction: column;
-            }
-            .selection-toolbar .button { justify-content: center; }
             .actions { justify-content: flex-start; }
             .filter-summary {
               align-items: stretch;
@@ -915,13 +852,6 @@ def render_page(page_name: str = "home") -> bytes:
                 <a class="button home-only" href="/gallery" id="view-gallery-button">View Gallery</a>
               </div>
             </div>
-            <div class="selection-toolbar">
-              <div class="selection-copy">
-                <p class="status" id="selection-status" aria-live="polite">0 of 10 photos selected</p>
-                <span class="selection-hint">Choose up to 10 photos to save together.</span>
-              </div>
-              <button class="button primary" id="save-selected-button" type="button" disabled>Save to phone</button>
-            </div>
             <div class="capture-browser" id="capture-browser"></div>
           </section>
 
@@ -939,7 +869,6 @@ def render_page(page_name: str = "home") -> bytes:
         <script>
           const isGalleryPage = document.body.dataset.page === "gallery";
           const HOME_GALLERY_LIMIT = __HOME_GALLERY_LIMIT__;
-          const MAX_SELECTED_PHOTOS = __MAX_SELECTED_PHOTOS__;
           const statusElement = document.getElementById("status");
           const latestFrame = document.getElementById("latest-frame");
           const captureInfo = document.getElementById("capture-info");
@@ -955,15 +884,9 @@ def render_page(page_name: str = "home") -> bytes:
           const recordButtonLabel = document.getElementById("record-button-label");
           const filterSummary = document.getElementById("filter-summary");
           const modeOptions = Array.from(document.querySelectorAll(".mode-option"));
-          const selectionStatus = document.getElementById("selection-status");
-          const saveSelectedButton = document.getElementById("save-selected-button");
           let captureImages = [];
           let totalCaptureCount = 0;
           let selectedCaptureIndex = 0;
-          const selectedPhotoPaths = new Set();
-          const preparedPhotoFiles = new Map();
-          const preparingPhotoFiles = new Map();
-          const failedPhotoPaths = new Set();
           let renderedCaptureKey = "";
           let renderedGalleryKey = "";
 
@@ -1009,7 +932,6 @@ def render_page(page_name: str = "home") -> bytes:
             const icons = {
               delete: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path><path d="M10 11v6"></path><path d="M14 11v6"></path></svg>',
               download: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="M7 10l5 5 5-5"></path><path d="M12 15V3"></path></svg>',
-              check: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 4 4L19 6"></path></svg>',
               video: '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="13" height="14" rx="2"></rect><path d="m16 10 5-3v10l-5-3Z"></path></svg>',
               play: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 7 8 5-8 5Z"></path></svg>',
             };
@@ -1119,151 +1041,8 @@ def render_page(page_name: str = "home") -> bytes:
             renderCaptureInfo(image);
           }
 
-          function photoPath(image) {
-            return image.relative_path || image.filename || "";
-          }
-
-          function selectedPhotos() {
-            return captureImages.filter(
-              (image) => image.media_type === "image" && selectedPhotoPaths.has(photoPath(image)),
-            );
-          }
-
-          function preparePhotoFile(image) {
-            const path = photoPath(image);
-            if (!path) return Promise.reject(new Error("Photo path is missing"));
-            if (preparedPhotoFiles.has(path)) {
-              return Promise.resolve(preparedPhotoFiles.get(path));
-            }
-            if (preparingPhotoFiles.has(path)) return preparingPhotoFiles.get(path);
-
-            failedPhotoPaths.delete(path);
-            const promise = fetch(image.view_url, { cache: "no-store" })
-              .then((response) => {
-                if (!response.ok) throw new Error(`Could not prepare ${image.filename || "photo"}`);
-                return response.blob();
-              })
-              .then((blob) => {
-                const file = new File(
-                  [blob],
-                  image.filename || "tiny-film-photo.jpg",
-                  {
-                    type: blob.type || "image/jpeg",
-                    lastModified: (image.modified_unix || Date.now() / 1000) * 1000,
-                  },
-                );
-                preparedPhotoFiles.set(path, file);
-                return file;
-              })
-              .catch((error) => {
-                failedPhotoPaths.add(path);
-                throw error;
-              })
-              .finally(() => {
-                preparingPhotoFiles.delete(path);
-                renderSelectionToolbar();
-              });
-            preparingPhotoFiles.set(path, promise);
-            renderSelectionToolbar();
-            return promise;
-          }
-
-          function renderSelectionToolbar(message = "") {
-            const count = selectedPhotoPaths.size;
-            const selectedPaths = Array.from(selectedPhotoPaths);
-            const isPreparing = selectedPaths.some((path) => preparingPhotoFiles.has(path));
-            const hasFailure = selectedPaths.some((path) => failedPhotoPaths.has(path));
-            selectionStatus.textContent = message || (isPreparing
-              ? `Preparing ${count} selected photo${count === 1 ? "" : "s"}...`
-              : hasFailure
-                ? "Some photos could not be prepared. Tap retry."
-                : `${count} of ${MAX_SELECTED_PHOTOS} photos selected`);
-            saveSelectedButton.disabled = count === 0 || isPreparing;
-            saveSelectedButton.textContent = hasFailure
-              ? "Retry preparation"
-              : count > 0
-                ? `Save ${count} photo${count === 1 ? "" : "s"}`
-                : "Save to phone";
-          }
-
-          function togglePhotoSelection(image) {
-            if (!image || image.media_type !== "image") return;
-            const path = photoPath(image);
-            if (selectedPhotoPaths.has(path)) {
-              selectedPhotoPaths.delete(path);
-              failedPhotoPaths.delete(path);
-            } else {
-              if (selectedPhotoPaths.size >= MAX_SELECTED_PHOTOS) {
-                renderSelectionToolbar(`You can select up to ${MAX_SELECTED_PHOTOS} photos.`);
-                return;
-              }
-              selectedPhotoPaths.add(path);
-              preparePhotoFile(image).catch(() => {});
-            }
-            renderedGalleryKey = "";
-            renderGallery();
-            renderSelectionToolbar();
-          }
-
-          function downloadPreparedFiles(files) {
-            files.forEach((file) => {
-              const link = document.createElement("a");
-              const objectUrl = URL.createObjectURL(file);
-              link.href = objectUrl;
-              link.download = file.name;
-              link.hidden = true;
-              document.body.appendChild(link);
-              link.click();
-              link.remove();
-              window.setTimeout(() => URL.revokeObjectURL(objectUrl), 60000);
-            });
-          }
-
-          async function saveSelectedPhotos() {
-            const photos = selectedPhotos();
-            if (!photos.length) return;
-            const missingPhotos = photos.filter((image) => !preparedPhotoFiles.has(photoPath(image)));
-            if (missingPhotos.length) {
-              await Promise.allSettled(missingPhotos.map((image) => preparePhotoFile(image)));
-              const stillMissing = photos.some((image) => !preparedPhotoFiles.has(photoPath(image)));
-              renderSelectionToolbar(
-                stillMissing
-                  ? "Some photos could not be prepared. Check the connection and retry."
-                  : "Photos are ready. Tap Save again.",
-              );
-              return;
-            }
-
-            const files = photos.map((image) => preparedPhotoFiles.get(photoPath(image)));
-            const shareData = { files, title: "Tiny Film photos" };
-            let canShareFiles = false;
-            if (typeof navigator.share === "function") {
-              try {
-                canShareFiles = typeof navigator.canShare !== "function" || navigator.canShare(shareData);
-              } catch (error) {
-                canShareFiles = false;
-              }
-            }
-            if (canShareFiles) {
-              selectionStatus.textContent = "Choose Save Images in the share sheet.";
-              try {
-                await navigator.share(shareData);
-                selectionStatus.textContent = `${files.length} photo${files.length === 1 ? "" : "s"} shared.`;
-                return;
-              } catch (error) {
-                if (error && error.name === "AbortError") {
-                  selectionStatus.textContent = "Save cancelled.";
-                  return;
-                }
-              }
-            }
-
-            downloadPreparedFiles(files);
-            selectionStatus.textContent = `Downloaded ${files.length} photo${files.length === 1 ? "" : "s"}.`;
-          }
-
           function renderGallery() {
-            const galleryKey = `${isGalleryPage}:${selectedCaptureIndex}:${Array.from(selectedPhotoPaths).join("|")}:${captureImages
+            const galleryKey = `${isGalleryPage}:${selectedCaptureIndex}:${captureImages
               .map((image) => `${image.relative_path}:${image.modified_unix}`)
               .join("|")}`;
             if (renderedGalleryKey === galleryKey) return;
@@ -1277,19 +1056,15 @@ def render_page(page_name: str = "home") -> bytes:
               : "";
             if (!captureImages.length) {
               captureBrowser.innerHTML = '<div class="empty">No captures yet.</div>';
-              renderSelectionToolbar();
               return;
             }
 
             const fragment = document.createDocumentFragment();
             captureImages.forEach((image, index) => {
-              const path = photoPath(image);
-              const photoSelected = selectedPhotoPaths.has(path);
               const item = document.createElement("div");
               item.className = [
                 "gallery-item",
                 !isGalleryPage && index === selectedCaptureIndex ? "selected" : "",
-                photoSelected ? "photo-selected" : "",
               ].filter(Boolean).join(" ");
 
               const previewButton = document.createElement("button");
@@ -1297,9 +1072,7 @@ def render_page(page_name: str = "home") -> bytes:
               previewButton.className = "gallery-preview";
               previewButton.setAttribute(
                 "aria-label",
-                isGalleryPage && image.media_type === "image"
-                  ? `${photoSelected ? "Deselect" : "Select"} ${image.filename || "photo"}`
-                  : `Preview ${image.filename || "capture"}`,
+                `Preview ${image.filename || "capture"}`,
               );
 
               const thumb = document.createElement("span");
@@ -1327,10 +1100,6 @@ def render_page(page_name: str = "home") -> bytes:
               caption.textContent = image.filename || image.relative_path || "Capture";
               previewButton.append(thumb, caption);
               previewButton.addEventListener("click", () => {
-                if (isGalleryPage && image.media_type === "image") {
-                  togglePhotoSelection(image);
-                  return;
-                }
                 if (isGalleryPage) {
                   window.open(image.view_url, "_blank", "noopener");
                   return;
@@ -1339,24 +1108,9 @@ def render_page(page_name: str = "home") -> bytes:
                 latestFrame.scrollIntoView({ block: "center" });
               });
               item.appendChild(previewButton);
-
-              if (image.media_type === "image") {
-                const selectButton = document.createElement("button");
-                selectButton.type = "button";
-                selectButton.className = "photo-select-button";
-                selectButton.setAttribute("aria-pressed", photoSelected ? "true" : "false");
-                selectButton.setAttribute(
-                  "aria-label",
-                  `${photoSelected ? "Deselect" : "Select"} ${image.filename || "photo"} to save`,
-                );
-                selectButton.innerHTML = iconSvg("check");
-                selectButton.addEventListener("click", () => togglePhotoSelection(image));
-                item.appendChild(selectButton);
-              }
               fragment.appendChild(item);
             });
             captureBrowser.appendChild(fragment);
-            renderSelectionToolbar();
           }
 
           function renderImages(images, options = {}) {
@@ -1364,12 +1118,6 @@ def render_page(page_name: str = "home") -> bytes:
             const previousPath = previousSelection && previousSelection.relative_path;
             captureImages = images;
             totalCaptureCount = Number.isFinite(options.totalImages) ? options.totalImages : images.length;
-            const availablePhotoPaths = new Set(
-              captureImages.filter((image) => image.media_type === "image").map(photoPath),
-            );
-            Array.from(selectedPhotoPaths).forEach((path) => {
-              if (!availablePhotoPaths.has(path)) selectedPhotoPaths.delete(path);
-            });
             if (Number.isFinite(options.selectedIndex)) {
               selectedCaptureIndex = clampCaptureIndex(options.selectedIndex, captureImages);
             } else if (options.selectLatest) {
@@ -1601,9 +1349,6 @@ def render_page(page_name: str = "home") -> bytes:
             }
           }
 
-          saveSelectedButton.addEventListener("click", () => {
-            saveSelectedPhotos();
-          });
           refreshImages().catch(() => {
             statusElement.textContent = "Could not load captures.";
           });
@@ -1633,7 +1378,6 @@ def render_page(page_name: str = "home") -> bytes:
     return (
         page.replace("__PAGE_NAME__", page_name)
         .replace("__HOME_GALLERY_LIMIT__", str(HOME_GALLERY_LIMIT))
-        .replace("__MAX_SELECTED_PHOTOS__", str(MAX_SELECTED_PHOTOS))
         .encode("utf-8")
     )
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -40,15 +40,14 @@ class RenderPageTest(unittest.TestCase):
         self.assertNotIn('id="filter-active-label"', page)
         self.assertNotIn('id="filter-state"', page)
 
-    def test_home_page_limits_the_gallery_and_supports_batch_photo_saving(self) -> None:
+    def test_home_page_limits_the_gallery_and_links_to_the_full_gallery(self) -> None:
         page = web.render_page().decode("utf-8")
 
         self.assertIn('data-page="home"', page)
         self.assertIn('href="/gallery"', page)
-        self.assertIn('id="save-selected-button"', page)
         self.assertIn("const HOME_GALLERY_LIMIT = 50", page)
-        self.assertIn("const MAX_SELECTED_PHOTOS = 10", page)
-        self.assertIn("navigator.share(shareData)", page)
+        self.assertNotIn('id="save-selected-button"', page)
+        self.assertNotIn("navigator.share", page)
 
     def test_gallery_page_has_a_back_control(self) -> None:
         page = web.render_page("gallery").decode("utf-8")


### PR DESCRIPTION
## Summary

- Remove photo selection controls and the Save to phone action from both gallery views.
- Retain the 50-capture home gallery, full gallery page, and Back navigation.

## Validation

- `python3 -m unittest discover -s tests`
- Generated JavaScript syntax check