### PR TITLE
Queue repeated camera captures and report readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,8 @@ TINY_FILM_BUTTON_BOUNCE_SECONDS=0.15
 TINY_FILM_BUZZER_PIN=18
 # 0 for the passive PWM module in the BOM, 1 for a simple active on/off buzzer.
 TINY_FILM_BUZZER_ACTIVE=0
-# Wait for systemd boot to finish, then allow final disk activity to settle
-# before playing the ready cue.
+# Wait for systemd boot to finish, allow final disk activity to settle, and
+# confirm that Picamera2 detects the camera before playing the ready cue.
 TINY_FILM_BUZZER_READY_DELAY_SECONDS=5
 # Photo cue: click (default), minimal, gentle, shutter, or sparkle.
 TINY_FILM_BUZZER_PHOTO_SOUND=click

--- a/docs/buzzer.md
+++ b/docs/buzzer.md
@@ -5,7 +5,7 @@ The shutter daemon (`src/tiny-film-cam/shutter_daemon.py`) drives these sounds:
 
 | Sound | When |
 |-------|------|
-| **minimal** | System startup finished and the settle delay elapsed (default ready cue) |
+| **minimal** | Startup settled and Picamera2 detected the camera (default ready cue) |
 | **click** | Frame captured (default; shorter/softer tick than minimal) |
 | **gentle** | Frame-captured option with a descending two-note cue |
 | **shutter** | Frame-captured option with two dry mechanical-style taps |
@@ -84,7 +84,8 @@ python3 src/tiny-film-cam/buzzer.py --sound gentle --volume 0.3
 
 No `.env` entries are required for the default wiring (GPIO 18, passive).
 With the defaults, the daemon waits for systemd to finish booting, allows five
-more seconds for startup disk activity to settle, and then plays `minimal` once
+more seconds for startup disk activity to settle, waits until Picamera2 detects
+the camera, and then plays `minimal` once
 at volume `0.90`. When the daemon is run outside systemd, only the five-second
 settle delay applies. A softer `click` at volume `0.30` plays immediately after
 the camera returns a frame, before rotation, JPEG encoding, and disk saving.

--- a/docs/shutter-button.md
+++ b/docs/shutter-button.md
@@ -74,8 +74,9 @@ For optional audible feedback from a passive buzzer module, see
 
 ## Notes
 
-- Pressing either button while a photo or video is already in progress is
-  ignored (no double-fires or overlapping access to the camera).
+- Button presses are queued and handled in order. A press received while a
+  photo or video is in progress runs as soon as the camera is free, without
+  overlapping camera access.
 - Holding a button does not change its action or repeatedly trigger it: the
   photo button takes one photo and the video button records one fixed-length
   clip per press.
@@ -83,3 +84,49 @@ For optional audible feedback from a passive buzzer module, see
   they appear in the gallery immediately.
 - If using pull-down wiring instead, connect the switch between GPIO and 3V3
   and pass `--pull-down`.
+
+## Readiness and repeated-photo test
+
+The startup ready cue now plays only after system startup has settled and
+Picamera2 detects a camera. Wait for that cue before taking the first photo. The
+same moment appears in the service log as `Tiny Film is ready for photos`.
+
+First test repeated camera capture without involving the physical switch. Stop
+the two camera-using services, load the deployed settings, and run five
+simulated presses exactly five seconds apart:
+
+```bash
+sudo systemctl stop tiny-film-shutter.service tiny-film-web.service
+set -a
+source .env
+set +a
+python3 src/tiny-film-cam/shutter_diagnostic.py --count 5 --interval 5
+sudo systemctl start tiny-film-web.service tiny-film-shutter.service
+```
+
+A successful run ends with `Diagnostic PASSED: 5/5 requests completed`. It also
+prints the time from each request to its sensor frame and saved JPEG. A failed
+run exits non-zero and prints the exception for the failed request.
+
+Then test the physical button while following the service log:
+
+```bash
+sudo journalctl -u tiny-film-shutter.service -f -o cat
+```
+
+After the ready cue, press the photo button five times with at least five
+seconds between presses. Each press must produce one uninterrupted sequence of
+messages with the same request number:
+
+```text
+Photo request #1 queued
+Photo request #1 started ... after button press
+Saved 1 photo(s): ...
+Photo request #1 finished in ...
+```
+
+If a press has no `queued` message, investigate the button wiring or GPIO
+input. If it queues and then logs `Capture failed`, investigate the camera or
+capture pipeline. A large `started ... after button press` value means an
+earlier photo or video was still using the camera; the request remains queued
+instead of being discarded.

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -378,6 +378,17 @@ def _available_camera_count(Picamera2) -> int | None:
     return len(cameras)
 
 
+def camera_is_available() -> bool:
+    """Return whether Picamera2 can currently see at least one camera."""
+    try:
+        from picamera2 import Picamera2
+    except ImportError:
+        return False
+
+    camera_count = _available_camera_count(Picamera2)
+    return camera_count is not None and camera_count > 0
+
+
 def _open_camera(Picamera2):
     camera_count = _available_camera_count(Picamera2)
     if camera_count == 0:

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import logging
 import os
+import queue
 import signal
 import subprocess
 import threading
+import time
 from pathlib import Path
+from typing import Callable, Literal
 
 from buzzer import (
     DEFAULT_PHOTO_SOUND,
@@ -19,6 +23,7 @@ from camera import (
     AWB_MODES,
     CaptureSettings,
     VideoSettings,
+    camera_is_available,
     capture_photos,
     capture_settings_from_env,
     record_video,
@@ -30,7 +35,126 @@ from photo_filters import selected_photo_filter_from_cache
 
 LOGGER = logging.getLogger("tiny_film.shutter")
 DEFAULT_BUZZER_READY_DELAY_SECONDS = 5.0
+DEFAULT_CAMERA_READY_POLL_SECONDS = 1.0
 SYSTEMD_RUNTIME_PATH = Path("/run/systemd/system")
+
+
+CaptureKind = Literal["photo", "video"]
+
+
+@dataclass(frozen=True)
+class CaptureRequest:
+    request_id: int
+    kind: CaptureKind
+    requested_at: float
+
+
+class CaptureRequestWorker:
+    """Run every accepted button request in order on one camera worker."""
+
+    _STOP = object()
+
+    def __init__(
+        self,
+        *,
+        take_photo: Callable[[], None],
+        record_clip: Callable[[], None],
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._handlers = {"photo": take_photo, "video": record_clip}
+        self._clock = clock
+        self._queue: queue.Queue[CaptureRequest | object] = queue.Queue()
+        self._state_lock = threading.Lock()
+        self._next_request_id = 1
+        self._accepting = True
+        self._started = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name="tiny-film-capture-worker",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        with self._state_lock:
+            if self._started:
+                return
+            self._started = True
+            self._thread.start()
+
+    def submit_photo(self) -> int | None:
+        return self._submit("photo")
+
+    def submit_video(self) -> int | None:
+        return self._submit("video")
+
+    def _submit(self, kind: CaptureKind) -> int | None:
+        with self._state_lock:
+            if not self._accepting:
+                LOGGER.info("Ignored %s button press during shutdown", kind)
+                return None
+            request = CaptureRequest(
+                request_id=self._next_request_id,
+                kind=kind,
+                requested_at=self._clock(),
+            )
+            self._next_request_id += 1
+            self._queue.put(request)
+
+        LOGGER.info(
+            "%s request #%s queued (%s request(s) waiting)",
+            kind.capitalize(),
+            request.request_id,
+            self._queue.qsize(),
+        )
+        return request.request_id
+
+    def wait_until_idle(self) -> None:
+        self._queue.join()
+
+    def stop(self) -> None:
+        with self._state_lock:
+            if not self._accepting:
+                return
+            self._accepting = False
+            self._queue.put(self._STOP)
+            started = self._started
+
+        if started:
+            self._thread.join()
+
+    def _run(self) -> None:
+        while True:
+            request = self._queue.get()
+            try:
+                if request is self._STOP:
+                    return
+                if not isinstance(request, CaptureRequest):
+                    continue
+
+                started_at = self._clock()
+                LOGGER.info(
+                    "%s request #%s started %.3fs after button press",
+                    request.kind.capitalize(),
+                    request.request_id,
+                    max(0.0, started_at - request.requested_at),
+                )
+                try:
+                    self._handlers[request.kind]()
+                except Exception:
+                    LOGGER.exception(
+                        "Unhandled error in %s request #%s",
+                        request.kind,
+                        request.request_id,
+                    )
+                finally:
+                    LOGGER.info(
+                        "%s request #%s finished in %.3fs",
+                        request.kind.capitalize(),
+                        request.request_id,
+                        max(0.0, self._clock() - started_at),
+                    )
+            finally:
+                self._queue.task_done()
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -137,6 +261,26 @@ def wait_for_system_startup(stop_event: threading.Event) -> bool:
     return not stop_event.is_set()
 
 
+def wait_for_camera_ready(
+    stop_event: threading.Event,
+    poll_seconds: float = DEFAULT_CAMERA_READY_POLL_SECONDS,
+) -> bool:
+    """Wait until Picamera2 reports a camera or shutdown is requested."""
+    first_check = True
+    while not stop_event.is_set():
+        if camera_is_available():
+            LOGGER.info("Camera detected and ready for shutter requests")
+            return True
+        if first_check:
+            LOGGER.warning(
+                "Camera is not available yet; delaying the ready cue and retrying"
+            )
+            first_check = False
+        if stop_event.wait(max(0.05, poll_seconds)):
+            return False
+    return False
+
+
 def play_ready_when_settled(
     *,
     buzzer: ShutterBuzzer,
@@ -156,8 +300,12 @@ def play_ready_when_settled(
     if stop_event.wait(delay_seconds):
         return
 
-    LOGGER.info("Startup settled; playing the ready cue")
-    buzzer.ready()
+    if not wait_for_camera_ready(stop_event):
+        return
+
+    LOGGER.info("Tiny Film is ready for photos")
+    if buzzer.enabled:
+        buzzer.ready()
 
 
 def parse_args() -> argparse.Namespace:
@@ -351,7 +499,6 @@ def main() -> None:
     args = parse_args()
     project_root = args.project_root.expanduser().resolve()
     output_dir = resolve_project_path(project_root, args.output_dir)
-    capture_lock = threading.Lock()
     stop_event = threading.Event()
     ready_thread: threading.Thread | None = None
     buzzer_pin = None if args.no_buzzer else args.buzzer_pin
@@ -376,13 +523,9 @@ def main() -> None:
         stop_event.set()
 
     def take_photo() -> None:
-        if not capture_lock.acquire(blocking=False):
-            LOGGER.info("Ignored button press because a capture is already running")
-            return
-
         try:
             photo_filter = selected_photo_filter_from_cache(project_root)
-            LOGGER.info("Button pressed; capturing photo with %s filter", photo_filter)
+            LOGGER.info("Capturing photo with %s filter", photo_filter)
             settings = CaptureSettings(
                 output_dir=output_dir,
                 width=args.width,
@@ -410,14 +553,8 @@ def main() -> None:
         except Exception:
             LOGGER.exception("Capture failed")
             buzzer.error()
-        finally:
-            capture_lock.release()
 
     def record_clip() -> None:
-        if not capture_lock.acquire(blocking=False):
-            LOGGER.info("Ignored video button because a capture is already running")
-            return
-
         try:
             LOGGER.info(
                 "Video button pressed; recording %.1fs video", args.video_duration
@@ -447,8 +584,12 @@ def main() -> None:
         except Exception:
             LOGGER.exception("Recording failed")
             buzzer.error()
-        finally:
-            capture_lock.release()
+
+    capture_worker = CaptureRequestWorker(
+        take_photo=take_photo,
+        record_clip=record_clip,
+    )
+    capture_worker.start()
 
     signal.signal(signal.SIGINT, request_stop)
     signal.signal(signal.SIGTERM, request_stop)
@@ -463,8 +604,8 @@ def main() -> None:
         pull_up=args.pull_up,
         bounce_time=args.bounce_time if args.bounce_time > 0 else None,
     )
-    photo_button.when_pressed = take_photo
-    video_button.when_pressed = record_clip
+    photo_button.when_pressed = capture_worker.submit_photo
+    video_button.when_pressed = capture_worker.submit_video
 
     wiring = (
         "GPIO-to-GND with pull-up" if args.pull_up else "GPIO-to-3V3 with pull-down"
@@ -490,29 +631,31 @@ def main() -> None:
             args.buzzer_photo_sound,
             args.buzzer_photo_volume,
         )
-        ready_thread = threading.Thread(
-            target=play_ready_when_settled,
-            kwargs={
-                "buzzer": buzzer,
-                "stop_event": stop_event,
-                "delay_seconds": args.buzzer_ready_delay,
-            },
-            name="tiny-film-ready-cue",
-            daemon=True,
-        )
-        ready_thread.start()
     elif args.no_buzzer or buzzer_pin is None:
         LOGGER.info("Buzzer feedback disabled")
+
+    ready_thread = threading.Thread(
+        target=play_ready_when_settled,
+        kwargs={
+            "buzzer": buzzer,
+            "stop_event": stop_event,
+            "delay_seconds": args.buzzer_ready_delay,
+        },
+        name="tiny-film-ready-cue",
+        daemon=True,
+    )
+    ready_thread.start()
 
     try:
         while not stop_event.wait(1.0):
             pass
     finally:
         stop_event.set()
-        if ready_thread is not None:
-            ready_thread.join(timeout=2.0)
         photo_button.close()
         video_button.close()
+        capture_worker.stop()
+        if ready_thread is not None:
+            ready_thread.join(timeout=2.0)
         buzzer.close()
 
 

--- a/src/tiny-film-cam/shutter_diagnostic.py
+++ b/src/tiny-film-cam/shutter_diagnostic.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, replace
+import logging
+from pathlib import Path
+import threading
+import time
+
+from camera import capture_photos, capture_settings_from_env
+from photo_filters import selected_photo_filter_from_cache
+from shutter_daemon import CaptureRequestWorker
+
+
+LOGGER = logging.getLogger("tiny_film.shutter_diagnostic")
+
+
+@dataclass(frozen=True)
+class DiagnosticResult:
+    attempt: int
+    duration_seconds: float
+    output_paths: tuple[Path, ...]
+    error: str | None = None
+
+
+def default_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Queue repeated Tiny Film photo requests and verify that each one saves."
+        )
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=default_project_root(),
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=5,
+        help="Number of photo requests to test (default: 5).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Seconds between simulated button presses (default: 5).",
+    )
+    return parser.parse_args()
+
+
+def run_diagnostic(project_root: Path, count: int, interval: float) -> bool:
+    if count <= 0:
+        raise ValueError("count must be greater than 0")
+    if interval < 0:
+        raise ValueError("interval cannot be negative")
+
+    project_root = project_root.expanduser().resolve()
+    settings = capture_settings_from_env(project_root)
+    results: list[DiagnosticResult] = []
+    result_lock = threading.Lock()
+    next_attempt = 1
+
+    def take_photo() -> None:
+        nonlocal next_attempt
+        attempt = next_attempt
+        next_attempt += 1
+        started_at = time.monotonic()
+        frame_at: float | None = None
+
+        def frame_captured() -> None:
+            nonlocal frame_at
+            frame_at = time.monotonic()
+            LOGGER.info(
+                "Diagnostic photo %s sensor frame returned after %.3fs",
+                attempt,
+                frame_at - started_at,
+            )
+
+        try:
+            capture_settings = replace(
+                settings,
+                photo_filter=selected_photo_filter_from_cache(project_root),
+            )
+            output_paths = tuple(
+                capture_photos(
+                    capture_settings,
+                    on_captured=frame_captured,
+                )
+            )
+            missing_paths = [
+                path
+                for path in output_paths
+                if not path.is_file() or path.stat().st_size == 0
+            ]
+            if missing_paths:
+                raise RuntimeError(f"empty or missing output: {missing_paths}")
+            result = DiagnosticResult(
+                attempt=attempt,
+                duration_seconds=time.monotonic() - started_at,
+                output_paths=output_paths,
+            )
+            LOGGER.info(
+                "Diagnostic photo %s saved in %.3fs: %s",
+                attempt,
+                result.duration_seconds,
+                list(output_paths),
+            )
+        except Exception as exc:
+            LOGGER.exception("Diagnostic photo %s failed", attempt)
+            result = DiagnosticResult(
+                attempt=attempt,
+                duration_seconds=time.monotonic() - started_at,
+                output_paths=(),
+                error=str(exc),
+            )
+
+        with result_lock:
+            results.append(result)
+
+    worker = CaptureRequestWorker(
+        take_photo=take_photo,
+        record_clip=lambda: None,
+    )
+    worker.start()
+    schedule_started_at = time.monotonic()
+    try:
+        for attempt in range(1, count + 1):
+            due_at = schedule_started_at + ((attempt - 1) * interval)
+            delay_seconds = due_at - time.monotonic()
+            if delay_seconds > 0:
+                time.sleep(delay_seconds)
+            submitted_at = time.monotonic()
+            worker.submit_photo()
+            LOGGER.info(
+                "Simulated press %s/%s at +%.3fs",
+                attempt,
+                count,
+                submitted_at - schedule_started_at,
+            )
+        worker.wait_until_idle()
+    finally:
+        worker.stop()
+
+    results.sort(key=lambda result: result.attempt)
+    passed = len(results) == count and all(result.error is None for result in results)
+    saved_count = sum(len(result.output_paths) for result in results)
+    LOGGER.info(
+        "Diagnostic %s: %s/%s requests completed, %s JPEG(s) saved",
+        "PASSED" if passed else "FAILED",
+        sum(result.error is None for result in results),
+        count,
+        saved_count,
+    )
+    for result in results:
+        if result.error is not None:
+            LOGGER.error("Photo %s error: %s", result.attempt, result.error)
+    return passed
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    args = parse_args()
+    try:
+        passed = run_diagnostic(args.project_root, args.count, args.interval)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_shutter_daemon.py
+++ b/tests/test_shutter_daemon.py
@@ -4,6 +4,7 @@ import importlib.util
 import os
 from pathlib import Path
 import sys
+import threading
 import types
 import unittest
 from unittest.mock import MagicMock, patch
@@ -51,6 +52,24 @@ class StopImmediatelyEvent:
 
     def wait(self, timeout: float) -> bool:
         return True
+
+
+class ImmediateCaptureWorker:
+    def __init__(self, *, take_photo, record_clip) -> None:
+        self.take_photo = take_photo
+        self.record_clip = record_clip
+
+    def start(self) -> None:
+        return None
+
+    def submit_photo(self) -> None:
+        self.take_photo()
+
+    def submit_video(self) -> None:
+        self.record_clip()
+
+    def stop(self) -> None:
+        return None
 
 
 class ShutterDaemonTest(unittest.TestCase):
@@ -105,11 +124,18 @@ class ShutterDaemonTest(unittest.TestCase):
         stop_event = MagicMock()
         stop_event.wait.return_value = False
 
-        with patch.object(
-            shutter_daemon,
-            "wait_for_system_startup",
-            return_value=True,
-        ) as wait_for_system_startup:
+        with (
+            patch.object(
+                shutter_daemon,
+                "wait_for_system_startup",
+                return_value=True,
+            ) as wait_for_system_startup,
+            patch.object(
+                shutter_daemon,
+                "wait_for_camera_ready",
+                return_value=True,
+            ) as wait_for_camera_ready,
+        ):
             shutter_daemon.play_ready_when_settled(
                 buzzer=buzzer,
                 stop_event=stop_event,
@@ -118,7 +144,61 @@ class ShutterDaemonTest(unittest.TestCase):
 
         wait_for_system_startup.assert_called_once_with(stop_event)
         stop_event.wait.assert_called_once_with(5.0)
+        wait_for_camera_ready.assert_called_once_with(stop_event)
         buzzer.ready.assert_called_once_with()
+
+    def test_camera_ready_wait_retries_until_camera_is_detected(self) -> None:
+        stop_event = MagicMock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.return_value = False
+
+        with patch.object(
+            shutter_daemon,
+            "camera_is_available",
+            side_effect=(False, True),
+        ) as camera_is_available:
+            ready = shutter_daemon.wait_for_camera_ready(
+                stop_event,
+                poll_seconds=1.0,
+            )
+
+        self.assertTrue(ready)
+        self.assertEqual(camera_is_available.call_count, 2)
+        stop_event.wait.assert_called_once_with(1.0)
+
+    def test_photo_press_is_queued_while_previous_capture_is_running(self) -> None:
+        first_started = threading.Event()
+        release_first = threading.Event()
+        second_finished = threading.Event()
+        capture_count = 0
+
+        def take_photo() -> None:
+            nonlocal capture_count
+            capture_count += 1
+            if capture_count == 1:
+                first_started.set()
+                self.assertTrue(release_first.wait(timeout=1.0))
+            else:
+                second_finished.set()
+
+        worker = shutter_daemon.CaptureRequestWorker(
+            take_photo=take_photo,
+            record_clip=lambda: None,
+        )
+        worker.start()
+        try:
+            first_request = worker.submit_photo()
+            self.assertTrue(first_started.wait(timeout=1.0))
+            second_request = worker.submit_photo()
+            release_first.set()
+            self.assertTrue(second_finished.wait(timeout=1.0))
+            worker.wait_until_idle()
+        finally:
+            release_first.set()
+            worker.stop()
+
+        self.assertEqual((first_request, second_request), (1, 2))
+        self.assertEqual(capture_count, 2)
 
     def test_ready_cue_is_cancelled_during_shutdown(self) -> None:
         buzzer = MagicMock()
@@ -215,6 +295,12 @@ class ShutterDaemonTest(unittest.TestCase):
                 "Event",
                 return_value=StopImmediatelyEvent(),
             ),
+            patch.object(
+                shutter_daemon,
+                "CaptureRequestWorker",
+                ImmediateCaptureWorker,
+            ),
+            patch.object(shutter_daemon.threading, "Thread"),
             patch.object(shutter_daemon.signal, "signal"),
         ):
             shutter_daemon.main()

--- a/tests/test_shutter_diagnostic.py
+++ b/tests/test_shutter_diagnostic.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "tiny-film-cam"
+DIAGNOSTIC_PATH = SOURCE_ROOT / "shutter_diagnostic.py"
+
+
+def load_shutter_diagnostic():
+    source_root = str(SOURCE_ROOT)
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+    spec = importlib.util.spec_from_file_location(
+        "tiny_film_shutter_diagnostic",
+        DIAGNOSTIC_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load diagnostic from {DIAGNOSTIC_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+shutter_diagnostic = load_shutter_diagnostic()
+
+
+class ShutterDiagnosticTest(unittest.TestCase):
+    def test_repeated_capture_passes_when_every_request_saves_a_jpeg(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            settings = shutter_diagnostic.capture_settings_from_env(project_root)
+            capture_number = 0
+
+            def capture_photos(capture_settings, on_captured):
+                nonlocal capture_number
+                capture_number += 1
+                on_captured()
+                output_path = (
+                    capture_settings.output_dir / f"diagnostic-{capture_number}.jpg"
+                )
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_bytes(b"jpeg")
+                return [output_path]
+
+            with (
+                patch.object(
+                    shutter_diagnostic,
+                    "capture_settings_from_env",
+                    return_value=settings,
+                ),
+                patch.object(
+                    shutter_diagnostic,
+                    "selected_photo_filter_from_cache",
+                    return_value="normal",
+                ),
+                patch.object(
+                    shutter_diagnostic,
+                    "capture_photos",
+                    side_effect=capture_photos,
+                ),
+            ):
+                passed = shutter_diagnostic.run_diagnostic(
+                    project_root,
+                    count=3,
+                    interval=0,
+                )
+
+        self.assertTrue(passed)
+        self.assertEqual(capture_number, 3)
+
+    def test_repeated_capture_fails_when_a_request_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            settings = shutter_diagnostic.capture_settings_from_env(project_root)
+            with (
+                patch.object(
+                    shutter_diagnostic,
+                    "capture_settings_from_env",
+                    return_value=settings,
+                ),
+                patch.object(
+                    shutter_diagnostic,
+                    "selected_photo_filter_from_cache",
+                    return_value="normal",
+                ),
+                patch.object(
+                    shutter_diagnostic,
+                    "capture_photos",
+                    side_effect=RuntimeError("camera busy"),
+                ),
+            ):
+                passed = shutter_diagnostic.run_diagnostic(
+                    project_root,
+                    count=1,
+                    interval=0,
+                )
+
+        self.assertFalse(passed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- wait for system startup to settle and for Picamera2 to detect a camera before emitting the ready cue and log
- enqueue photo and video button requests on one serial worker so presses are preserved without overlapping camera access
- add request timing logs and a repeated-capture diagnostic that defaults to five photos at five-second intervals
- document how to distinguish GPIO misses from camera pipeline failures

## Root cause

The GPIO callback performed the entire capture synchronously, while a non-blocking lock discarded requests received during an active photo or video. A slow capture could therefore block event handling or cause a later press to be ignored. The previous ready cue was also based only on boot timing and did not confirm camera detection.

## Validation

- `ruff check src/tiny-film-cam/camera.py src/tiny-film-cam/shutter_daemon.py src/tiny-film-cam/shutter_diagnostic.py tests/test_shutter_daemon.py tests/test_shutter_diagnostic.py`
- `python3 -m unittest discover -s tests` (76 tests)

The hardware diagnostic still needs to be run on the Raspberry Pi with the production camera and GPIO wiring.