### PR TITLE
Document USB serial Wi-Fi recovery

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -45,3 +45,6 @@ If SSH is refused, make sure the SSH service is enabled and running on the Pi
 sudo systemctl enable --now ssh
 ```
 
+If the Pi has no network connection and no mini-HDMI display is available, use
+the [USB serial Wi-Fi recovery guide](usb-serial-wifi-recovery.md) to log in and
+repair its NetworkManager profile without reflashing the SD card.

--- a/docs/usb-serial-wifi-recovery.md
+++ b/docs/usb-serial-wifi-recovery.md
@@ -1,0 +1,93 @@
+# Recover Wi-Fi over USB Serial
+
+Use this procedure when a Raspberry Pi Zero 2 W will not join Wi-Fi and no
+mini-HDMI display is available. It provides a temporary login console through
+the Pi's micro-USB data port; the SD card does not need to be reflashed.
+
+## Root cause found
+
+The hotspot credentials stored on the boot partition were correct, the Wi-Fi
+radio was enabled, and the Pi could see the 2.4 GHz hotspot. However,
+`nmcli connection show` contained no saved Wi-Fi profile, so NetworkManager had
+nothing to connect to automatically.
+
+## Enable the temporary serial console
+
+Shut down the Pi, put its SD card in another computer, and back up `config.txt`
+and `cmdline.txt` from the `bootfs` partition.
+
+Add this under `[all]` in `config.txt`:
+
+```ini
+dtoverlay=dwc2,dr_mode=peripheral
+```
+
+Add these space-separated parameters to the existing single line in
+`cmdline.txt`:
+
+```text
+modules-load=dwc2,g_serial console=ttyGS0,115200 systemd.wants=serial-getty@ttyGS0.service
+```
+
+Keep all existing `cmdline.txt` content on that same line. Safely eject the SD
+card and return it to the Pi.
+
+Connect a known data-capable micro-USB cable between the computer and the Pi's
+port labelled **USB**, not **PWR IN**. This cable supplies both data and power;
+do not attach a second power source at the same time.
+
+On macOS, locate and open the serial device:
+
+```bash
+ls /dev/cu.usbmodem*
+screen /dev/cu.usbmodem11301 115200
+```
+
+Replace `usbmodem11301` with the name reported on the host. On Linux, the
+device is usually `/dev/ttyACM0`. Press Enter if the login prompt is not
+immediately visible, then log in with the Pi user account.
+
+## Diagnose and connect
+
+Check the radio, interface, saved profiles, and visible networks:
+
+```bash
+nmcli radio
+nmcli device status
+rfkill list
+nmcli connection show
+sudo nmcli device wifi rescan ifname wlan0
+nmcli -f IN-USE,SSID,CHAN,FREQ,SIGNAL,SECURITY device wifi list ifname wlan0
+```
+
+If the hotspot is visible but has no saved profile, create one without putting
+the password in shell history:
+
+```bash
+sudo nmcli --ask device wifi connect "<SSID>" ifname wlan0
+```
+
+Enter the hotspot password when prompted. Confirm the connection, IP address,
+route, and automatic reconnection:
+
+```bash
+nmcli device status
+ip -4 -br address show wlan0
+ip route
+nmcli -g connection.autoconnect connection show "<SSID>"
+ping -c 3 1.1.1.1
+```
+
+## Remove the temporary console
+
+After Wi-Fi and SSH work, remove the added `dtoverlay` line from `config.txt`
+and the three added parameters from `cmdline.txt`:
+
+```text
+modules-load=dwc2,g_serial
+console=ttyGS0,115200
+systemd.wants=serial-getty@ttyGS0.service
+```
+
+Reboot the Pi. Removing the temporary console avoids leaving a physical USB
+login interface enabled.


### PR DESCRIPTION
## What changed

- Add a concise, reproducible Raspberry Pi Zero 2 W USB-serial Wi-Fi recovery guide.
- Link the guide from the existing network troubleshooting documentation.

## Why

The Pi could see the 2.4 GHz hotspot and had valid credentials, but NetworkManager had no saved Wi-Fi profile. The guide documents how to obtain a serial login without reflashing, create the missing profile with `nmcli`, verify connectivity and autoconnect, and remove the temporary serial console afterward.

## Impact

Users without a mini-HDMI display can recover a Pi that is offline using a data-capable micro-USB cable and the existing SD card.

## Validation

- Reproduced the serial login and NetworkManager recovery on a Raspberry Pi Zero 2 W.
- Confirmed hotspot, gateway, and internet connectivity after creating the profile.
- Ran `git diff --cached --check`.
- Confirmed the troubleshooting link resolves to the new guide.
