### PR TITLE
Add Vivid 50 photo filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ TINY_FILM_FILTER_LEFT_PIN=26
 TINY_FILM_FILTER_RIGHT_PIN=20
 TINY_FILM_FILTER_LEFT=black_and_white
 TINY_FILM_FILTER_CENTER=normal
+# Photo filters: black_and_white, normal, cold, or vivid_50.
 TINY_FILM_FILTER_RIGHT=cold
 TINY_FILM_FILTER_CACHE_PATH=data/filter-state.json
 TINY_FILM_FILTER_POLL_SECONDS=0.05
@@ -76,6 +77,7 @@ TINY_FILM_CAPTURE_AWB_MODE=daylight
 TINY_FILM_CAPTURE_AWB_LOCK=0
 # Used by direct/env-driven captures. Web and shutter photos use the live
 # SS23D32 state, falling back to Normal if that state is unavailable or stale.
+# Photo filters: black_and_white, normal, cold, or vivid_50.
 TINY_FILM_CAPTURE_FILTER=normal
 # Clockwise rotation applied to the saved JPEG pixels: 0, 90, 180, or 270.
 TINY_FILM_CAPTURE_ROTATION=0

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,6 +31,21 @@ python3 src/tiny-film-cam/capture.py \
 python3 src/tiny-film-cam/capture.py
 ```
 
+## Take a photo with the Vivid 50 approximation
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --output vivid-50.jpg \
+  --photo-filter vivid_50
+```
+
+The app's `vivid_50` look includes a selective colour boost and tone curve that
+the Raspberry Pi ISP controls cannot express. For a faster, ISP-only rough
+approximation without the app's JPEG post-processing, use:
+
+```bash
+rpicam-still -o vivid-50-rough.jpg --contrast 1.12 --saturation 1.15
+```
+
 ## Take a full-size Camera Module 3 photo
 ```bash
 python3 src/tiny-film-cam/capture.py --width 4608 --height 2592

--- a/docs/filter-switch.md
+++ b/docs/filter-switch.md
@@ -64,6 +64,13 @@ TINY_FILM_FILTER_LEFT=cold
 TINY_FILM_FILTER_RIGHT=black_and_white
 ```
 
+To put the Vivid 50 approximation on one of the three switch positions, assign
+`vivid_50` to that position. For example, this replaces Cold on the right:
+
+```dotenv
+TINY_FILM_FILTER_RIGHT=vivid_50
+```
+
 ## 4. Install and verify the service
 
 ```bash

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -18,7 +18,14 @@ Choose one of the three JPEG looks directly with:
 python3 src/tiny-film-cam/capture.py --photo-filter black_and_white
 python3 src/tiny-film-cam/capture.py --photo-filter normal
 python3 src/tiny-film-cam/capture.py --photo-filter cold
+python3 src/tiny-film-cam/capture.py --photo-filter vivid_50
 ```
+
+`vivid_50` is a versioned approximation of the iPhone Photos **Vivid** filter
+at 50% intensity. It applies an S-curve, selective vibrance, and saturation,
+then blends the result 50/50 with the captured pixels. Apple does not publish
+the original transform, so it is intentionally labelled as an approximation in
+the photo metadata.
 
 If `--output` is omitted, the script writes a timestamped JPEG into
 `data/captures/YYYY-MM-DD/`.

--- a/src/tiny-film-cam/photo_filters.py
+++ b/src/tiny-film-cam/photo_filters.py
@@ -6,9 +6,9 @@ from typing import Literal, cast
 from filter_switch import filter_status_from_cache
 
 
-PhotoFilterName = Literal["black_and_white", "normal", "cold"]
+PhotoFilterName = Literal["black_and_white", "normal", "cold", "vivid_50"]
 DEFAULT_PHOTO_FILTER: PhotoFilterName = "normal"
-PHOTO_FILTER_NAMES = ("black_and_white", "normal", "cold")
+PHOTO_FILTER_NAMES = ("black_and_white", "normal", "cold", "vivid_50")
 PHOTO_FILTER_DETAILS: dict[PhotoFilterName, dict[str, object]] = {
     "black_and_white": {
         "id": "black_and_white",
@@ -25,7 +25,20 @@ PHOTO_FILTER_DETAILS: dict[PhotoFilterName, dict[str, object]] = {
         "label": "Cold",
         "version": 1,
     },
+    "vivid_50": {
+        "id": "vivid_50",
+        "label": "Vivid 50",
+        "version": 1,
+        "intensity_percent": 50,
+        "approximation": True,
+    },
 }
+
+VIVID_50_BLEND = 0.5
+VIVID_FULL_CONTRAST = 1.22
+VIVID_FULL_SATURATION = 1.18
+VIVID_FULL_VIBRANCE = 0.35
+VIVID_FULL_TONE_CURVE = 0.20
 
 
 def normalize_photo_filter(value: object) -> PhotoFilterName:
@@ -65,6 +78,53 @@ def _scaled_lut(multiplier: float) -> list[int]:
     return [max(0, min(255, round(value * multiplier))) for value in range(256)]
 
 
+def _vibrance_lut(amount: float) -> list[int]:
+    """Boost muted colours more than colours already near full saturation."""
+    return [
+        max(
+            0,
+            min(
+                255,
+                round(value + amount * value * (1.0 - value / 255.0)),
+            ),
+        )
+        for value in range(256)
+    ]
+
+
+def _s_curve_lut(amount: float) -> list[int]:
+    """Return a gentle, endpoint-preserving contrast curve."""
+    lut = []
+    for value in range(256):
+        normalized = value / 255.0
+        smoothstep = normalized * normalized * (3.0 - 2.0 * normalized)
+        curved = normalized + amount * (smoothstep - normalized)
+        lut.append(max(0, min(255, round(curved * 255.0))))
+    return lut
+
+
+def _apply_rgb_lut(image, lut: list[int]):
+    from PIL import Image
+
+    red, green, blue = image.split()
+    return Image.merge("RGB", (red.point(lut), green.point(lut), blue.point(lut)))
+
+
+def _apply_vivid_50(rgb_image):
+    """Approximate Apple's Vivid filter, blended to its 50% slider position."""
+    from PIL import Image, ImageEnhance
+
+    vivid = ImageEnhance.Contrast(rgb_image).enhance(VIVID_FULL_CONTRAST)
+    vivid = _apply_rgb_lut(vivid, _s_curve_lut(VIVID_FULL_TONE_CURVE))
+
+    hue, saturation, value = vivid.convert("HSV").split()
+    saturation = saturation.point(_vibrance_lut(VIVID_FULL_VIBRANCE))
+    vivid = Image.merge("HSV", (hue, saturation, value)).convert("RGB")
+    vivid = ImageEnhance.Color(vivid).enhance(VIVID_FULL_SATURATION)
+
+    return Image.blend(rgb_image, vivid, VIVID_50_BLEND)
+
+
 def apply_photo_filter(image, name: PhotoFilterName):
     """Apply a lightweight, versioned photo look to a Pillow image."""
     if name == "normal":
@@ -76,6 +136,9 @@ def apply_photo_filter(image, name: PhotoFilterName):
     if name == "black_and_white":
         grayscale = ImageOps.grayscale(rgb_image)
         return ImageEnhance.Contrast(grayscale).enhance(1.08).convert("RGB")
+
+    if name == "vivid_50":
+        return _apply_vivid_50(rgb_image)
 
     muted = ImageEnhance.Color(rgb_image).enhance(0.88)
     red, green, blue = muted.split()

--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -495,6 +495,10 @@ def render_page(page_name: str = "home") -> bytes:
             background: #dce9ff;
             color: #285ba9;
           }
+          [data-filter="vivid_50"] .mode-icon {
+            background: linear-gradient(135deg, #ffb24a, #ff4f81 52%, #635bff);
+            color: #fff;
+          }
           .battery-summary {
             align-items: center;
             color: #367552;
@@ -837,6 +841,12 @@ def render_page(page_name: str = "home") -> bytes:
                     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2v20M4 6l16 12M20 6 4 18M8.5 4 12 6l3.5-2M8.5 20l3.5-2 3.5 2M3.5 10 7 12l-3.5 2M20.5 10 17 12l3.5 2"></path></svg>
                   </span>
                   <span>Cold</span>
+                </div>
+                <div class="mode-option" data-filter="vivid_50" role="listitem">
+                  <span class="mode-icon">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2 1.7 5.3L19 9l-5.3 1.7L12 16l-1.7-5.3L5 9l5.3-1.7Z"></path><path d="m18.5 15 .8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8Z"></path></svg>
+                  </span>
+                  <span>Vivid 50</span>
                 </div>
               </div>
             </div>

--- a/tests/test_photo_filters.py
+++ b/tests/test_photo_filters.py
@@ -48,6 +48,45 @@ class PhotoFiltersTest(unittest.TestCase):
         self.assertLess(red, green)
         self.assertGreater(blue, green)
 
+    def test_vivid_50_increases_colour_and_tonal_separation(self) -> None:
+        image = Image.new("RGB", (2, 1))
+        image.putpixel((0, 0), (75, 60, 50))
+        image.putpixel((1, 0), (180, 155, 130))
+
+        filtered = photo_filters.apply_photo_filter(image, "vivid_50")
+
+        original_saturation = [
+            image.convert("HSV").getpixel((x, 0))[1] for x in range(2)
+        ]
+        filtered_saturation = [
+            filtered.convert("HSV").getpixel((x, 0))[1] for x in range(2)
+        ]
+        original_luminance_range = (
+            image.convert("L").getpixel((1, 0))
+            - image.convert("L").getpixel((0, 0))
+        )
+        filtered_luminance_range = (
+            filtered.convert("L").getpixel((1, 0))
+            - filtered.convert("L").getpixel((0, 0))
+        )
+
+        self.assertTrue(
+            all(
+                filtered_value > original_value
+                for filtered_value, original_value in zip(
+                    filtered_saturation, original_saturation, strict=True
+                )
+            )
+        )
+        self.assertGreater(filtered_luminance_range, original_luminance_range)
+
+    def test_vivid_50_metadata_identifies_approximation_and_intensity(self) -> None:
+        details = photo_filters.photo_filter_details("vivid_50")
+
+        self.assertEqual(details["label"], "Vivid 50")
+        self.assertEqual(details["intensity_percent"], 50)
+        self.assertTrue(details["approximation"])
+
     def test_fresh_switch_selection_is_used(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
@@ -172,6 +211,7 @@ class PhotoFiltersTest(unittest.TestCase):
         self.assertIn('data-filter="black_and_white"', page)
         self.assertIn('data-filter="normal"', page)
         self.assertIn('data-filter="cold"', page)
+        self.assertIn('data-filter="vivid_50"', page)
         self.assertIn("option.dataset.filter === activeFilterId", page)
 
     def test_web_page_uses_a_stable_preview_and_multi_item_gallery(self) -> None:


### PR DESCRIPTION
## Summary

- add a versioned `vivid_50` photo filter with a 50% blend
- approximate the iPhone Vivid look with an S-curve, selective vibrance, saturation, and contrast
- expose the filter through the capture CLI, web mode display, environment configuration, and physical switch mapping
- document both the full filter and a faster ISP-only rough approximation

## Why

Apple does not publish the underlying Vivid colour transform. Tiny Film therefore needs an explicit, reproducible approximation rather than treating Vivid 50 as a fixed set of Raspberry Pi ISP controls.

## Impact

Users can capture with `--photo-filter vivid_50` or assign `vivid_50` to a hardware switch position. Saved metadata identifies the 50% intensity and records that the look is an approximation.

## Validation

- `python3 -m unittest discover -s tests -v` (78 tests passed)
- `git diff --check`
- `python3 -m compileall -q src/tiny-film-cam tests`
- visually checked the filter against the repository camera sample for colour, contrast, and clipping
