### PR TITLE
Preserve video recording duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ cd tiny-film-camera
 
 sudo apt update
 sudo apt install -y \
-  python3-picamera2 python3-pil python3-gpiozero python3-smbus \
-  i2c-tools ffmpeg
+  python3-picamera2 python3-av python3-pil python3-gpiozero \
+  python3-smbus i2c-tools
 
 cp .env.example .env
 ./scripts/install_service.sh --enable-now

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,9 +22,9 @@
    ```bash
    rpicam-vid -t 5000 -o test.mp4
    ```
-7. Install Python helpers (`ffmpeg` is required for MP4 video recording):
+7. Install Python helpers (`python3-av` preserves camera timestamps in MP4 recordings):
    ```bash
-   sudo apt install -y python3-picamera2 python3-pil python3-gpiozero python3-smbus i2c-tools ffmpeg
+   sudo apt install -y python3-picamera2 python3-av python3-pil python3-gpiozero python3-smbus i2c-tools
    ```
 8. Enable I2C for the Waveshare UPS HAT (C):
    ```bash

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -76,8 +76,9 @@ Record a short video (H.264/MP4, 10s by default) into the same
 python3 src/tiny-film-cam/record.py --duration 10
 ```
 
-Video recording requires `ffmpeg` on the Pi (`sudo apt install ffmpeg`) and only
-supports rotation 0 or 180.
+Video recording requires PyAV on the Pi (`sudo apt install python3-av`) and only
+supports rotation 0 or 180. PyAV preserves camera timestamps when frames arrive
+late, so recordings keep their requested real-world duration.
 
 Run the capture browser:
 

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -541,11 +541,11 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
 
     try:
         from picamera2.encoders import H264Encoder
-        from picamera2.outputs import FfmpegOutput
+        from picamera2.outputs import PyavOutput
     except ImportError as exc:
         raise CameraCaptureError(
-            "Missing Picamera2 video encoders. Install ffmpeg on the Pi with "
-            "`sudo apt install ffmpeg`."
+            "Missing Picamera2 video dependencies. Install them on the Pi with "
+            "`sudo apt install python3-picamera2 python3-av`."
         ) from exc
 
     if settings.duration_seconds <= 0:
@@ -562,7 +562,10 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
             controls["FrameRate"] = float(settings.fps)
 
         config = picam2.create_video_configuration(
-            main={"size": (settings.width, settings.height)},
+            main={
+                "size": (settings.width, settings.height),
+                "format": "YUV420",
+            },
             controls=controls,
             transform=_video_transform(settings.rotation),
         )
@@ -570,7 +573,7 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
         encoder = (
             H264Encoder(bitrate=settings.bitrate) if settings.bitrate else H264Encoder()
         )
-        output = FfmpegOutput(str(output_path))
+        output = PyavOutput(str(output_path))
         started = False
 
         try:

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 import importlib.util
 from pathlib import Path
 import sys
+from tempfile import TemporaryDirectory
+from types import ModuleType
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -54,6 +57,65 @@ class CameraRotationTest(unittest.TestCase):
         self.assertEqual(camera.DEFAULT_VIDEO_FPS, 15)
         self.assertEqual(camera.VideoSettings().fps, 15)
         self.assertEqual(settings.fps, 15)
+
+    def test_video_recording_preserves_timestamps_and_uses_yuv420(self) -> None:
+        picam2 = MagicMock()
+        encoder = object()
+        output = object()
+        h264_encoder = MagicMock(return_value=encoder)
+        pyav_output = MagicMock(return_value=output)
+        picamera2_module = ModuleType("picamera2")
+        picamera2_module.Picamera2 = object  # type: ignore[attr-defined]
+        encoders_module = ModuleType("picamera2.encoders")
+        encoders_module.H264Encoder = h264_encoder  # type: ignore[attr-defined]
+        outputs_module = ModuleType("picamera2.outputs")
+        outputs_module.PyavOutput = pyav_output  # type: ignore[attr-defined]
+
+        with TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "clip.mp4"
+            settings = camera.VideoSettings(
+                output_dir=Path(temporary_directory),
+                filename=str(output_path),
+                duration_seconds=10,
+                warmup_seconds=0,
+                rotation=0,
+            )
+            with (
+                patch.dict(
+                    sys.modules,
+                    {
+                        "picamera2": picamera2_module,
+                        "picamera2.encoders": encoders_module,
+                        "picamera2.outputs": outputs_module,
+                    },
+                ),
+                patch.object(
+                    camera,
+                    "_locked_camera",
+                    return_value=nullcontext(),
+                ),
+                patch.object(camera, "_open_camera", return_value=picam2),
+                patch.object(camera, "_video_transform", return_value=None),
+                patch("time.sleep") as sleep,
+            ):
+                saved_path = camera.record_video(settings)
+
+        self.assertEqual(saved_path, output_path)
+        h264_encoder.assert_called_once_with()
+        pyav_output.assert_called_once_with(str(output_path))
+        picam2.create_video_configuration.assert_called_once_with(
+            main={"size": (1280, 720), "format": "YUV420"},
+            controls={
+                "Sharpness": 0.3,
+                "Contrast": 0.85,
+                "Saturation": 0.9,
+                "ExposureValue": -0.7,
+                "FrameRate": 15.0,
+            },
+            transform=None,
+        )
+        picam2.start_recording.assert_called_once_with(encoder, output)
+        sleep.assert_called_once_with(10)
 
     def test_capture_settings_default_rotation_is_180(self) -> None:
         with patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
## Summary

- replace `FfmpegOutput` with timestamp-aware `PyavOutput` for MP4 recording
- feed the H.264 encoder YUV420 frames to reduce work on the Raspberry Pi Zero 2 W
- document the PyAV runtime dependency
- add regression coverage for the output and camera-stream configuration

## Root cause

`FfmpegOutput` cannot receive Picamera2 capture timestamps. It timestamps encoded frames when they reach its FFmpeg subprocess. On the Pi Zero 2 W, frames can arrive in bursts, causing ten seconds of captured content to be muxed into a roughly seven-second MP4 and play too quickly.

An observed 15 FPS sample contained 119 frames and reported 7.14 seconds, while a stopwatch visible in its first and last frames advanced by about 9.9 seconds.

`PyavOutput` muxes Picamera2’s per-frame timestamps directly, so dropped or delayed frames no longer compress the recording timeline.

## Video format

- resolution: 1280 × 720 (720p, 16:9)
- target frame rate: 15 FPS
- codec/container: H.264 in MP4

## Validation

- `python3 -m unittest discover -s tests -v` (77 tests passed)
- `ruff check src tests`
- `ruff format --check src/tiny-film-cam/camera.py tests/test_camera_rotation.py`
- `git diff --check`