### PR TITLE
Finalize videos for browser playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cd tiny-film-camera
 
 sudo apt update
 sudo apt install -y \
-  python3-picamera2 python3-av python3-pil python3-gpiozero \
+  ffmpeg python3-picamera2 python3-av python3-pil python3-gpiozero \
   python3-smbus i2c-tools
 
 cp .env.example .env

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,9 +22,10 @@
    ```bash
    rpicam-vid -t 5000 -o test.mp4
    ```
-7. Install Python helpers (`python3-av` preserves camera timestamps in MP4 recordings):
+7. Install the camera helpers (`python3-av` preserves camera timestamps and
+   `ffmpeg` finalizes browser-friendly MP4 recordings):
    ```bash
-   sudo apt install -y python3-picamera2 python3-av python3-pil python3-gpiozero python3-smbus i2c-tools
+   sudo apt install -y ffmpeg python3-picamera2 python3-av python3-pil python3-gpiozero python3-smbus i2c-tools
    ```
 8. Enable I2C for the Waveshare UPS HAT (C):
    ```bash

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -76,9 +76,11 @@ Record a short video (H.264/MP4, 10s by default) into the same
 python3 src/tiny-film-cam/record.py --duration 10
 ```
 
-Video recording requires PyAV on the Pi (`sudo apt install python3-av`) and only
-supports rotation 0 or 180. PyAV preserves camera timestamps when frames arrive
-late, so recordings keep their requested real-world duration.
+Video recording requires PyAV and ffmpeg on the Pi
+(`sudo apt install python3-av ffmpeg`) and only supports rotation 0 or 180.
+PyAV preserves camera timestamps when frames arrive late, then ffmpeg losslessly
+places the MP4 index at the front so recordings retain their real-world duration
+and play reliably in phone browsers.
 
 Run the capture browser:
 

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import fcntl
 import os
 from pathlib import Path
+import subprocess
 from typing import Callable, Iterator, Literal
 
 from capture_metadata import write_photo_filter_metadata
@@ -527,6 +528,52 @@ def _video_transform(rotation: Rotation):
     return Transform()
 
 
+def _video_recording_path(output_path: Path) -> Path:
+    return output_path.with_name(f".{output_path.name}.recording.mkv")
+
+
+def _finalize_video(recording_path: Path, output_path: Path) -> None:
+    """Losslessly finalize timestamped H.264 as a browser-friendly MP4."""
+    finalizing_path = output_path.with_name(f".{output_path.name}.finalizing")
+    finalizing_path.unlink(missing_ok=True)
+
+    command = [
+        "ffmpeg",
+        "-y",
+        "-v",
+        "error",
+        "-i",
+        str(recording_path),
+        "-map",
+        "0:v:0",
+        "-c:v",
+        "copy",
+        "-tag:v",
+        "avc1",
+        "-movflags",
+        "+faststart",
+        "-f",
+        "mp4",
+        str(finalizing_path),
+    ]
+
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        os.replace(finalizing_path, output_path)
+    except FileNotFoundError as exc:
+        raise CameraCaptureError(
+            "Missing ffmpeg. Install it on the Pi with `sudo apt install ffmpeg`."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() if exc.stderr else ""
+        message = "ffmpeg could not finalize the video recording."
+        if detail:
+            message = f"{message} {detail}"
+        raise CameraCaptureError(message) from exc
+    finally:
+        finalizing_path.unlink(missing_ok=True)
+
+
 def record_video(settings: VideoSettings = VideoSettings()) -> Path:
     """Record a short H.264/MP4 clip from a Raspberry Pi Camera Module 3."""
     import time
@@ -570,26 +617,33 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
             transform=_video_transform(settings.rotation),
         )
         output_path = _video_output_path(settings)
+        recording_path = _video_recording_path(output_path)
+        recording_path.unlink(missing_ok=True)
         encoder = (
             H264Encoder(bitrate=settings.bitrate) if settings.bitrate else H264Encoder()
         )
-        output = PyavOutput(str(output_path))
         started = False
 
         try:
-            picam2.configure(config)
-            picam2.start()
-            started = True
-            if settings.warmup_seconds > 0:
-                time.sleep(settings.warmup_seconds)
-            _apply_awb_lock(picam2, settings)
+            output = PyavOutput(str(recording_path))
+            try:
+                picam2.configure(config)
+                picam2.start()
+                started = True
+                if settings.warmup_seconds > 0:
+                    time.sleep(settings.warmup_seconds)
+                _apply_awb_lock(picam2, settings)
 
-            picam2.start_recording(encoder, output)
-            time.sleep(settings.duration_seconds)
-            picam2.stop_recording()
+                picam2.start_recording(encoder, output)
+                time.sleep(settings.duration_seconds)
+                picam2.stop_recording()
+            finally:
+                if started:
+                    picam2.stop()
+                picam2.close()
+
+            _finalize_video(recording_path, output_path)
         finally:
-            if started:
-                picam2.stop()
-            picam2.close()
+            recording_path.unlink(missing_ok=True)
 
         return output_path

--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -1048,7 +1048,7 @@ def render_page(page_name: str = "home") -> bytes:
               preview.controls = true;
               preview.playsInline = true;
               preview.setAttribute("playsinline", "");
-              preview.preload = "metadata";
+              preview.preload = "auto";
               preview.src = previewSrc;
               preview.addEventListener("error", () => renderMediaError(image), { once: true });
             } else {

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -96,13 +96,16 @@ class CameraRotationTest(unittest.TestCase):
                 ),
                 patch.object(camera, "_open_camera", return_value=picam2),
                 patch.object(camera, "_video_transform", return_value=None),
+                patch.object(camera, "_finalize_video") as finalize_video,
                 patch("time.sleep") as sleep,
             ):
                 saved_path = camera.record_video(settings)
 
         self.assertEqual(saved_path, output_path)
         h264_encoder.assert_called_once_with()
-        pyav_output.assert_called_once_with(str(output_path))
+        recording_path = output_path.with_name(f".{output_path.name}.recording.mkv")
+        pyav_output.assert_called_once_with(str(recording_path))
+        finalize_video.assert_called_once_with(recording_path, output_path)
         picam2.create_video_configuration.assert_called_once_with(
             main={"size": (1280, 720), "format": "YUV420"},
             controls={
@@ -116,6 +119,30 @@ class CameraRotationTest(unittest.TestCase):
         )
         picam2.start_recording.assert_called_once_with(encoder, output)
         sleep.assert_called_once_with(10)
+
+    def test_video_finalization_copies_h264_into_fast_start_mp4(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            recording_path = Path(temporary_directory) / "recording.mkv"
+            output_path = Path(temporary_directory) / "clip.mp4"
+            recording_path.write_bytes(b"matroska")
+
+            def fake_run(command, **kwargs):
+                Path(command[-1]).write_bytes(b"mp4")
+                return None
+
+            with patch.object(camera.subprocess, "run", side_effect=fake_run) as run:
+                camera._finalize_video(recording_path, output_path)
+
+            command = run.call_args.args[0]
+            self.assertEqual(output_path.read_bytes(), b"mp4")
+            self.assertIn("copy", command)
+            self.assertIn("avc1", command)
+            self.assertIn("+faststart", command)
+            self.assertEqual(command[-3:-1], ["-f", "mp4"])
+            self.assertEqual(
+                run.call_args.kwargs,
+                {"check": True, "capture_output": True, "text": True},
+            )
 
     def test_capture_settings_default_rotation_is_180(self) -> None:
         with patch.dict("os.environ", {}, clear=True):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -40,6 +40,11 @@ class RenderPageTest(unittest.TestCase):
         self.assertNotIn('id="filter-active-label"', page)
         self.assertNotIn('id="filter-state"', page)
 
+    def test_selected_video_preloads_its_first_frame(self) -> None:
+        page = web.render_page().decode("utf-8")
+
+        self.assertIn('preview.preload = "auto"', page)
+
     def test_home_page_limits_the_gallery_and_links_to_the_full_gallery(self) -> None:
         page = web.render_page().decode("utf-8")
 


### PR DESCRIPTION
## Summary
- record timestamped H.264 into a temporary Matroska container
- losslessly remux each completed clip into a fast-start MP4 with an `avc1` tag
- eagerly preload the selected video so phone browsers display its first frame
- document the ffmpeg runtime dependency

## Validation
- `python3 -m unittest discover -s tests` (80 tests)
- Raspberry Pi test recording: 1280x720, 15 FPS, 45 frames over 2.974 seconds
- Exact reported clip after finalization: 150 frames over 9.974 seconds, `moov` atom before `mdat`
- Browser decode: 1280x720, 9.974 seconds, readyState 4, no media error