### PR TITLE
Show video previews in Safari

### DIFF
--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -80,7 +80,9 @@ Video recording requires PyAV and ffmpeg on the Pi
 (`sudo apt install python3-av ffmpeg`) and only supports rotation 0 or 180.
 PyAV preserves camera timestamps when frames arrive late, then ffmpeg losslessly
 places the MP4 index at the front so recordings retain their real-world duration
-and play reliably in phone browsers.
+and play reliably in phone browsers. Each new video also gets a small
+`<video-name>.poster.jpg` preview for Safari; poster files stay out of the
+gallery and are removed with their video.
 
 Run the capture browser:
 

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -532,10 +532,19 @@ def _video_recording_path(output_path: Path) -> Path:
     return output_path.with_name(f".{output_path.name}.recording.mkv")
 
 
+def video_poster_path(output_path: Path) -> Path:
+    return output_path.with_name(f"{output_path.name}.poster.jpg")
+
+
 def _finalize_video(recording_path: Path, output_path: Path) -> None:
-    """Losslessly finalize timestamped H.264 as a browser-friendly MP4."""
+    """Finalize timestamped H.264 and create its Safari poster image."""
     finalizing_path = output_path.with_name(f".{output_path.name}.finalizing")
+    poster_path = video_poster_path(output_path)
+    poster_finalizing_path = output_path.with_name(
+        f".{output_path.name}.poster.finalizing.jpg"
+    )
     finalizing_path.unlink(missing_ok=True)
+    poster_finalizing_path.unlink(missing_ok=True)
 
     command = [
         "ffmpeg",
@@ -555,10 +564,22 @@ def _finalize_video(recording_path: Path, output_path: Path) -> None:
         "-f",
         "mp4",
         str(finalizing_path),
+        "-map",
+        "0:v:0",
+        "-frames:v",
+        "1",
+        "-q:v",
+        "3",
+        "-update",
+        "1",
+        "-f",
+        "image2",
+        str(poster_finalizing_path),
     ]
 
     try:
         subprocess.run(command, check=True, capture_output=True, text=True)
+        os.replace(poster_finalizing_path, poster_path)
         os.replace(finalizing_path, output_path)
     except FileNotFoundError as exc:
         raise CameraCaptureError(
@@ -572,6 +593,7 @@ def _finalize_video(recording_path: Path, output_path: Path) -> None:
         raise CameraCaptureError(message) from exc
     finally:
         finalizing_path.unlink(missing_ok=True)
+        poster_finalizing_path.unlink(missing_ok=True)
 
 
 def record_video(settings: VideoSettings = VideoSettings()) -> Path:

--- a/src/tiny-film-cam/web.py
+++ b/src/tiny-film-cam/web.py
@@ -21,6 +21,7 @@ from camera import (
     capture_photo,
     capture_settings_from_env,
     record_video,
+    video_poster_path,
     video_settings_from_env,
 )
 from photo_filters import (
@@ -51,7 +52,16 @@ def is_capture_image_file(path: Path) -> bool:
     return (
         path.is_file()
         and not path.name.startswith(".")
+        and not path.name.lower().endswith(".mp4.poster.jpg")
         and path.suffix.lower() in CAPTURE_SUFFIXES
+    )
+
+
+def is_video_poster_file(path: Path) -> bool:
+    return (
+        path.is_file()
+        and not path.name.startswith(".")
+        and path.name.lower().endswith(".mp4.poster.jpg")
     )
 
 
@@ -77,6 +87,21 @@ def get_capture_image_by_relative_path(
     except ValueError:
         return None
     if is_capture_image_file(candidate):
+        return candidate
+    return None
+
+
+def get_capture_media_by_relative_path(
+    project_root: Path, relative_path: str
+) -> Path | None:
+    root = captures_root(project_root)
+    decoded_relative = unquote(relative_path).lstrip("/")
+    candidate = (root / decoded_relative).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return None
+    if is_capture_image_file(candidate) or is_video_poster_file(candidate):
         return candidate
     return None
 
@@ -119,6 +144,11 @@ def build_capture_image(project_root: Path, image_path: Path) -> dict[str, objec
     stat = image_path.stat()
     metadata = read_capture_metadata(image_path)
     photo_filter = metadata.get("photo_filter")
+    poster_path = video_poster_path(image_path)
+    poster_url = None
+    if media_type_for(image_path) == "video" and poster_path.is_file():
+        poster_relative_path = poster_path.resolve().relative_to(root).as_posix()
+        poster_url = f"/image/captures/{quote(poster_relative_path)}"
     return {
         "filename": image_path.name,
         "relative_path": relative_path,
@@ -128,6 +158,7 @@ def build_capture_image(project_root: Path, image_path: Path) -> dict[str, objec
         "delete_url": f"/api/captures/{quote(relative_path)}",
         "modified_unix": stat.st_mtime,
         "size_bytes": stat.st_size,
+        "poster_url": poster_url,
         "photo_filter": photo_filter if isinstance(photo_filter, dict) else None,
     }
 
@@ -183,6 +214,8 @@ def delete_capture_image(
     deleted_path = image_path.relative_to(root).as_posix()
     deleted_name = image_path.name
     image_path.unlink()
+    if media_type_for(image_path) == "video":
+        video_poster_path(image_path).unlink(missing_ok=True)
     delete_capture_metadata(image_path)
     remove_empty_capture_dirs(project_root, image_path.parent)
     return {
@@ -1049,7 +1082,10 @@ def render_page(page_name: str = "home") -> bytes:
               preview.playsInline = true;
               preview.setAttribute("playsinline", "");
               preview.preload = "auto";
-              preview.src = previewSrc;
+              if (image.poster_url) {
+                preview.poster = `${image.poster_url}?v=${encodeURIComponent(image.modified_unix || "")}`;
+              }
+              preview.src = `${previewSrc}#t=0.001`;
               preview.addEventListener("error", () => renderMediaError(image), { once: true });
             } else {
               preview = document.createElement("img");
@@ -1630,7 +1666,7 @@ def build_handler(project_root: Path, port: int):
 
             if request_path.startswith("/image/captures/"):
                 relative_path = request_path[len("/image/captures/") :]
-                image_path = get_capture_image_by_relative_path(
+                image_path = get_capture_media_by_relative_path(
                     project_root, relative_path
                 )
                 if image_path is None:
@@ -1659,7 +1695,7 @@ def build_handler(project_root: Path, port: int):
                 return
             if request_path.startswith("/image/captures/"):
                 relative_path = request_path[len("/image/captures/") :]
-                image_path = get_capture_image_by_relative_path(
+                image_path = get_capture_media_by_relative_path(
                     project_root, relative_path
                 )
                 if image_path is None:

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -127,7 +127,9 @@ class CameraRotationTest(unittest.TestCase):
             recording_path.write_bytes(b"matroska")
 
             def fake_run(command, **kwargs):
-                Path(command[-1]).write_bytes(b"mp4")
+                second_map = command.index("-map", command.index("-map") + 1)
+                Path(command[second_map - 1]).write_bytes(b"mp4")
+                Path(command[-1]).write_bytes(b"jpeg")
                 return None
 
             with patch.object(camera.subprocess, "run", side_effect=fake_run) as run:
@@ -135,10 +137,13 @@ class CameraRotationTest(unittest.TestCase):
 
             command = run.call_args.args[0]
             self.assertEqual(output_path.read_bytes(), b"mp4")
+            self.assertEqual(
+                camera.video_poster_path(output_path).read_bytes(), b"jpeg"
+            )
             self.assertIn("copy", command)
             self.assertIn("avc1", command)
             self.assertIn("+faststart", command)
-            self.assertEqual(command[-3:-1], ["-f", "mp4"])
+            self.assertIn("image2", command)
             self.assertEqual(
                 run.call_args.kwargs,
                 {"check": True, "capture_output": True, "text": True},

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -44,6 +44,8 @@ class RenderPageTest(unittest.TestCase):
         page = web.render_page().decode("utf-8")
 
         self.assertIn('preview.preload = "auto"', page)
+        self.assertIn("preview.poster = `${image.poster_url}", page)
+        self.assertIn('preview.src = `${previewSrc}#t=0.001`', page)
 
     def test_home_page_limits_the_gallery_and_links_to_the_full_gallery(self) -> None:
         page = web.render_page().decode("utf-8")
@@ -90,6 +92,10 @@ class CaptureMediaServerTest(unittest.TestCase):
         )
         self.capture_path.parent.mkdir(parents=True)
         self.capture_path.write_bytes(b"0123456789")
+        self.poster_path = self.capture_path.with_name(
+            f"{self.capture_path.name}.poster.jpg"
+        )
+        self.poster_path.write_bytes(b"jpeg-poster")
         self.server = web.ThreadingHTTPServer(
             ("127.0.0.1", 0),
             web.build_handler(self.project_root, 0),
@@ -132,6 +138,35 @@ class CaptureMediaServerTest(unittest.TestCase):
         self.assertEqual(headers["Content-Range"], "bytes 2-5/10")
         self.assertEqual(headers["Content-Length"], "4")
         self.assertEqual(headers["Content-Type"], "video/mp4")
+
+    def test_video_poster_is_served_but_not_listed_as_a_capture(self) -> None:
+        status, headers, body = self.request(
+            "GET",
+            path="/image/captures/2026-08-10/clip.mp4.poster.jpg",
+        )
+        api_status, _, api_body = self.request("GET", path="/api/images")
+        payload = json.loads(api_body)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["Content-Type"], "image/jpeg")
+        self.assertEqual(body, b"jpeg-poster")
+        self.assertEqual(api_status, 200)
+        self.assertEqual(
+            [item["filename"] for item in payload["images"]], ["clip.mp4"]
+        )
+        self.assertEqual(
+            payload["images"][0]["poster_url"],
+            "/image/captures/2026-08-10/clip.mp4.poster.jpg",
+        )
+
+    def test_deleting_video_also_deletes_its_poster(self) -> None:
+        deleted = web.delete_capture_image(
+            self.project_root, "2026-08-10/clip.mp4"
+        )
+
+        self.assertIsNotNone(deleted)
+        self.assertFalse(self.capture_path.exists())
+        self.assertFalse(self.poster_path.exists())
 
     def test_unsatisfied_range_returns_416_with_file_size(self) -> None:
         status, headers, body = self.request("GET", {"Range": "bytes=20-30"})


### PR DESCRIPTION
## Summary
- generate a first-frame JPEG poster while finalizing each new MP4
- expose the poster URL without listing the sidecar as a separate gallery capture
- attach posters to the video player and use a `#t=0.001` media-fragment fallback for existing clips
- remove each poster when its video is deleted

## Why
iOS Safari does not reliably honor `preload=auto` for paused videos, so a valid video can appear as a blank surface even though its duration is loaded. Apple recommends an explicit poster image for this case.

## Validation
- `python3 -m unittest discover -s tests` (82 tests)
- exact reported 10.239s clip: generated a valid 1280x720 baseline JPEG poster while preserving all 145 video frames
- Raspberry Pi end-to-end test from this branch: 45 frames over 2.974s at 1280x720, valid 1280x720 JPEG poster, fast-start MP4