### PR TITLE
Encode videos for Safari compatibility

### DIFF
--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -631,19 +631,30 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
             controls["FrameRate"] = float(settings.fps)
 
         config = picam2.create_video_configuration(
-            main={
-                "size": (settings.width, settings.height),
-                "format": "YUV420",
-            },
+            # Let Picamera2 choose its normal RGB stream. Forcing YUV420 here
+            # drops the BT.709 colour metadata from the Pi's encoded H.264,
+            # which makes otherwise valid clips render blank in Safari.
+            main={"size": (settings.width, settings.height)},
             controls=controls,
             transform=_video_transform(settings.rotation),
         )
         output_path = _video_output_path(settings)
         recording_path = _video_recording_path(output_path)
         recording_path.unlink(missing_ok=True)
-        encoder = (
-            H264Encoder(bitrate=settings.bitrate) if settings.bitrate else H264Encoder()
-        )
+        encoder_options: dict[str, object] = {
+            "profile": "constrained baseline",
+        }
+        if settings.bitrate:
+            encoder_options["bitrate"] = settings.bitrate
+        if settings.fps > 0:
+            encoder_options.update(
+                {
+                    "framerate": float(settings.fps),
+                    "enable_sps_framerate": True,
+                    "iperiod": settings.fps * 2,
+                }
+            )
+        encoder = H264Encoder(**encoder_options)
         started = False
 
         try:

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -58,7 +58,9 @@ class CameraRotationTest(unittest.TestCase):
         self.assertEqual(camera.VideoSettings().fps, 15)
         self.assertEqual(settings.fps, 15)
 
-    def test_video_recording_preserves_timestamps_and_uses_yuv420(self) -> None:
+    def test_video_recording_preserves_timestamps_and_encoder_colour_metadata(
+        self,
+    ) -> None:
         picam2 = MagicMock()
         encoder = object()
         output = object()
@@ -102,12 +104,17 @@ class CameraRotationTest(unittest.TestCase):
                 saved_path = camera.record_video(settings)
 
         self.assertEqual(saved_path, output_path)
-        h264_encoder.assert_called_once_with()
+        h264_encoder.assert_called_once_with(
+            profile="constrained baseline",
+            framerate=15.0,
+            enable_sps_framerate=True,
+            iperiod=30,
+        )
         recording_path = output_path.with_name(f".{output_path.name}.recording.mkv")
         pyav_output.assert_called_once_with(str(recording_path))
         finalize_video.assert_called_once_with(recording_path, output_path)
         picam2.create_video_configuration.assert_called_once_with(
-            main={"size": (1280, 720), "format": "YUV420"},
+            main={"size": (1280, 720)},
             controls={
                 "Sharpness": 0.3,
                 "Contrast": 0.85,


### PR DESCRIPTION
## Summary
- restore BT.709 range, primaries, transfer, and colour-space metadata in encoded H.264
- encode as Constrained Baseline H.264 for broad iPhone/iPad Safari support
- write explicit 15 FPS timing into the SPS and insert a keyframe every two seconds
- retain PyAV timestamps, fast-start MP4 finalization, and first-frame posters

## Root cause
The Safari regression began in #72. Forcing YUV420 removed BT.709 metadata, and the resulting High Profile stream is rejected by the affected Safari decoder after it dismisses the JPEG poster. Letting Picamera2 use its normal RGB stream restores colour metadata, while Constrained Baseline plus explicit SPS timing produces the most widely compatible H.264 stream without a slow software re-encode.

## Validation
- `python3 -m unittest discover -s tests` (82 tests)
- real Raspberry Pi recording: H.264 Constrained Baseline/avc1, 1280x720, 15 FPS, 45 frames over 2.974 seconds
- `color_range=tv`; colour space, transfer, and primaries are all `bt709`
- explicit frame timing and two keyframes in the three-second test clip
- first-frame JPEG poster still generated