### PR TITLE
Replace cool filter with cinematic teal-and-gold grade

### DIFF
--- a/src/tiny-film-cam/photo_filters.py
+++ b/src/tiny-film-cam/photo_filters.py
@@ -23,7 +23,7 @@ PHOTO_FILTER_DETAILS: dict[PhotoFilterName, dict[str, object]] = {
     "cool": {
         "id": "cool",
         "label": "Cool",
-        "version": 1,
+        "version": 2,
     },
 }
 
@@ -65,20 +65,55 @@ def _scaled_lut(multiplier: float) -> list[int]:
     return [max(0, min(255, round(value * multiplier))) for value in range(256)]
 
 
+def _mask_lut(start: int, end: int, *, invert: bool = False) -> list[int]:
+    """Build a smooth luminance mask without requiring NumPy on the camera."""
+    values = []
+    for value in range(256):
+        position = max(0.0, min(1.0, (value - start) / (end - start)))
+        smooth = position * position * (3.0 - 2.0 * position)
+        if invert:
+            smooth = 1.0 - smooth
+        values.append(round(smooth * 255))
+    return values
+
+
+def _scaled_mask(mask, amount: float):
+    return mask.point(_scaled_lut(amount))
+
+
 def apply_photo_filter(image, name: PhotoFilterName):
     """Apply a lightweight, versioned photo look to a Pillow image."""
     if name == "normal":
         return image
 
-    from PIL import Image, ImageEnhance, ImageOps
+    from PIL import Image, ImageChops, ImageEnhance, ImageFilter, ImageOps
 
     rgb_image = image.convert("RGB")
     if name == "black_and_white":
         grayscale = ImageOps.grayscale(rgb_image)
         return ImageEnhance.Contrast(grayscale).enhance(1.08).convert("RGB")
 
-    muted = ImageEnhance.Color(rgb_image).enhance(0.88)
-    red, green, blue = muted.split()
-    red = red.point(_scaled_lut(0.93))
-    blue = blue.point(_scaled_lut(1.10))
-    return Image.merge("RGB", (red, green, blue))
+    # A portable Pillow version of the golden-hour teal-and-amber grade. Keep
+    # this filter dependency-light because it runs directly on the camera Pi.
+    graded = ImageEnhance.Contrast(rgb_image).enhance(1.18)
+    graded = graded.point(_scaled_lut(1.0 / 0.96) * 3)
+    graded = ImageEnhance.Color(graded).enhance(1.14)
+
+    luminance = ImageOps.grayscale(graded)
+    shadow_mask = luminance.point(_mask_lut(36, 148, invert=True))
+    highlight_mask = luminance.point(_mask_lut(96, 232))
+
+    red, green, blue = graded.split()
+
+    # Teal shadows.
+    red = ImageChops.subtract(red, _scaled_mask(shadow_mask, 0.050))
+    green = ImageChops.add(green, _scaled_mask(shadow_mask, 0.020))
+    blue = ImageChops.add(blue, _scaled_mask(shadow_mask, 0.042))
+
+    # Amber/golden highlights.
+    red = ImageChops.add(red, _scaled_mask(highlight_mask, 0.100))
+    green = ImageChops.add(green, _scaled_mask(highlight_mask, 0.044))
+    blue = ImageChops.subtract(blue, _scaled_mask(highlight_mask, 0.050))
+
+    graded = Image.merge("RGB", (red, green, blue))
+    return graded.filter(ImageFilter.UnsharpMask(radius=1.15, percent=32, threshold=3))

--- a/tests/test_photo_filters.py
+++ b/tests/test_photo_filters.py
@@ -39,14 +39,26 @@ class PhotoFiltersTest(unittest.TestCase):
         self.assertEqual(red, green)
         self.assertEqual(green, blue)
 
-    def test_cool_filter_reduces_red_and_raises_blue(self) -> None:
-        image = Image.new("RGB", (1, 1), (100, 100, 100))
+    def test_cool_filter_adds_teal_to_shadows(self) -> None:
+        image = Image.new("RGB", (1, 1), (60, 60, 60))
 
         filtered = photo_filters.apply_photo_filter(image, "cool")
 
         red, green, blue = filtered.getpixel((0, 0))
         self.assertLess(red, green)
         self.assertGreater(blue, green)
+
+    def test_cool_filter_adds_gold_to_highlights(self) -> None:
+        image = Image.new("RGB", (1, 1), (210, 210, 210))
+
+        filtered = photo_filters.apply_photo_filter(image, "cool")
+
+        red, green, blue = filtered.getpixel((0, 0))
+        self.assertGreater(red, green)
+        self.assertGreater(green, blue)
+
+    def test_cool_filter_metadata_version_tracks_new_grade(self) -> None:
+        self.assertEqual(photo_filters.photo_filter_details("cool")["version"], 2)
 
     def test_fresh_switch_selection_is_used(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- replace the simple blue cool filter with a cinematic teal-shadow and golden-highlight grade
- keep processing Pillow-only for Raspberry Pi compatibility
- sharpen output subtly and bump cool filter metadata to version 2
- test shadow, highlight, and metadata behavior

## Testing
- python3 -m unittest discover -s tests (84 tests passed)