### PR TITLE
Normalize video output for Safari

### DIFF
--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -76,11 +76,13 @@ Record a short video (H.264/MP4, 10s by default) into the same
 python3 src/tiny-film-cam/record.py --duration 10
 ```
 
-Video recording requires PyAV and ffmpeg on the Pi
+Video recording requires PyAV, ffmpeg, and its `libx264` encoder on the Pi
 (`sudo apt install python3-av ffmpeg`) and only supports rotation 0 or 180.
-PyAV preserves camera timestamps when frames arrive late, then ffmpeg losslessly
-places the MP4 index at the front so recordings retain their real-world duration
-and play reliably in phone browsers. Each new video also gets a small
+PyAV preserves camera timestamps when frames arrive late. ffmpeg then converts
+the recording to constant-frame-rate H.264 that plays reliably in Safari and
+places the MP4 index at the front. This final conversion takes additional time
+after the requested footage has been recorded, so a 10-second clip takes longer
+than 10 seconds to finish. Each new video also gets a small
 `<video-name>.poster.jpg` preview for Safari; poster files stay out of the
 gallery and are removed with their video.
 

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -536,8 +536,13 @@ def video_poster_path(output_path: Path) -> Path:
     return output_path.with_name(f"{output_path.name}.poster.jpg")
 
 
-def _finalize_video(recording_path: Path, output_path: Path) -> None:
-    """Finalize timestamped H.264 and create its Safari poster image."""
+def _finalize_video(
+    recording_path: Path,
+    output_path: Path,
+    fps: int,
+    bitrate: int | None = None,
+) -> None:
+    """Create a Safari-compatible CFR H.264 MP4 and its poster image."""
     finalizing_path = output_path.with_name(f".{output_path.name}.finalizing")
     poster_path = video_poster_path(output_path)
     poster_finalizing_path = output_path.with_name(
@@ -546,6 +551,7 @@ def _finalize_video(recording_path: Path, output_path: Path) -> None:
     finalizing_path.unlink(missing_ok=True)
     poster_finalizing_path.unlink(missing_ok=True)
 
+    rate_control = ["-b:v", str(bitrate)] if bitrate is not None else []
     command = [
         "ffmpeg",
         "-y",
@@ -555,8 +561,37 @@ def _finalize_video(recording_path: Path, output_path: Path) -> None:
         str(recording_path),
         "-map",
         "0:v:0",
+        "-an",
+        "-vf",
+        (
+            f"fps={fps},setparams=range=limited:color_primaries=bt709:"
+            "color_trc=bt709:colorspace=bt709"
+        ),
         "-c:v",
-        "copy",
+        "libx264",
+        "-preset",
+        "ultrafast",
+        "-profile:v",
+        "baseline",
+        "-level:v",
+        "3.1",
+        "-pix_fmt",
+        "yuv420p",
+        "-g",
+        str(fps * 2),
+        "-keyint_min",
+        str(fps * 2),
+        "-sc_threshold",
+        "0",
+        "-color_range",
+        "tv",
+        "-colorspace",
+        "bt709",
+        "-color_trc",
+        "bt709",
+        "-color_primaries",
+        "bt709",
+        *rate_control,
         "-tag:v",
         "avc1",
         "-movflags",
@@ -619,6 +654,8 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
 
     if settings.duration_seconds <= 0:
         raise CameraCaptureError("Video duration must be greater than 0 seconds.")
+    if settings.fps <= 0:
+        raise CameraCaptureError("Video FPS must be greater than 0.")
     if settings.rotation not in VIDEO_ONLY_ROTATIONS:
         raise CameraCaptureError(
             f"Video recording only supports rotation 0 or 180. Got {settings.rotation}."
@@ -627,8 +664,7 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
     with _locked_camera(settings.output_dir.expanduser()):
         picam2 = _open_camera(Picamera2)
         controls = _camera_controls(settings)
-        if settings.fps > 0:
-            controls["FrameRate"] = float(settings.fps)
+        controls["FrameRate"] = float(settings.fps)
 
         config = picam2.create_video_configuration(
             main={
@@ -664,7 +700,12 @@ def record_video(settings: VideoSettings = VideoSettings()) -> Path:
                     picam2.stop()
                 picam2.close()
 
-            _finalize_video(recording_path, output_path)
+            _finalize_video(
+                recording_path,
+                output_path,
+                settings.fps,
+                settings.bitrate,
+            )
         finally:
             recording_path.unlink(missing_ok=True)
 

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -105,7 +105,7 @@ class CameraRotationTest(unittest.TestCase):
         h264_encoder.assert_called_once_with()
         recording_path = output_path.with_name(f".{output_path.name}.recording.mkv")
         pyav_output.assert_called_once_with(str(recording_path))
-        finalize_video.assert_called_once_with(recording_path, output_path)
+        finalize_video.assert_called_once_with(recording_path, output_path, 15, None)
         picam2.create_video_configuration.assert_called_once_with(
             main={"size": (1280, 720), "format": "YUV420"},
             controls={
@@ -120,7 +120,7 @@ class CameraRotationTest(unittest.TestCase):
         picam2.start_recording.assert_called_once_with(encoder, output)
         sleep.assert_called_once_with(10)
 
-    def test_video_finalization_copies_h264_into_fast_start_mp4(self) -> None:
+    def test_video_finalization_transcodes_safari_compatible_h264(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             recording_path = Path(temporary_directory) / "recording.mkv"
             output_path = Path(temporary_directory) / "clip.mp4"
@@ -133,14 +133,23 @@ class CameraRotationTest(unittest.TestCase):
                 return None
 
             with patch.object(camera.subprocess, "run", side_effect=fake_run) as run:
-                camera._finalize_video(recording_path, output_path)
+                camera._finalize_video(recording_path, output_path, 15)
 
             command = run.call_args.args[0]
             self.assertEqual(output_path.read_bytes(), b"mp4")
             self.assertEqual(
                 camera.video_poster_path(output_path).read_bytes(), b"jpeg"
             )
-            self.assertIn("copy", command)
+            self.assertNotIn("copy", command)
+            self.assertIn("libx264", command)
+            self.assertIn("ultrafast", command)
+            self.assertIn("baseline", command)
+            self.assertIn("3.1", command)
+            video_filter = command[command.index("-vf") + 1]
+            self.assertIn("fps=15", video_filter)
+            self.assertIn("setparams=range=limited", video_filter)
+            self.assertIn("yuv420p", command)
+            self.assertIn("bt709", command)
             self.assertIn("avc1", command)
             self.assertIn("+faststart", command)
             self.assertIn("image2", command)
@@ -148,6 +157,25 @@ class CameraRotationTest(unittest.TestCase):
                 run.call_args.kwargs,
                 {"check": True, "capture_output": True, "text": True},
             )
+
+    def test_video_finalization_preserves_requested_bitrate(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            recording_path = Path(temporary_directory) / "recording.mkv"
+            output_path = Path(temporary_directory) / "clip.mp4"
+            recording_path.write_bytes(b"matroska")
+
+            def fake_run(command, **kwargs):
+                second_map = command.index("-map", command.index("-map") + 1)
+                Path(command[second_map - 1]).write_bytes(b"mp4")
+                Path(command[-1]).write_bytes(b"jpeg")
+                return None
+
+            with patch.object(camera.subprocess, "run", side_effect=fake_run) as run:
+                camera._finalize_video(recording_path, output_path, 15, 4_000_000)
+
+            command = run.call_args.args[0]
+            bitrate_option = command.index("-b:v")
+            self.assertEqual(command[bitrate_option + 1], "4000000")
 
     def test_capture_settings_default_rotation_is_180(self) -> None:
         with patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
## Summary
- transcode timestamped camera output with software `libx264`, the encoder confirmed to play in Safari
- produce 15 FPS CFR, Constrained Baseline Level 3.1, `yuv420p`, BT.709, `avc1` fast-start MP4s
- retain poster generation and preserve an explicitly configured bitrate
- document that Safari-compatible finalization adds processing time after recording

## Raspberry Pi validation
- recorded a new 10-second clip through the production `record.py` path
- output: 1280x720, 15/1 FPS, exactly 10.000 seconds and 150 frames
- codec: H.264 Constrained Baseline Level 3.1, `avc1`, `yuv420p`, limited-range BT.709
- inspected first and last frames; both decode correctly and contain distinct scene content
- measured libx264 normalization at 21.4 seconds for a 10-second 720p source; full camera command took 50.1 seconds on this Pi

## Tests
- `python3 -m unittest discover -s tests` (83 passed)