### PR TITLE
Use Wes-inspired grading for the Cool toggle and photo CLI

### DIFF
--- a/docs/wes-anderson-filter.md
+++ b/docs/wes-anderson-filter.md
@@ -61,13 +61,17 @@ are identical. JPEG files can differ if encoder settings differ.
 
 ## Physical switch
 
-The CLI filter is installed on the Pi. Existing hardware switch mappings were
-left in place. To assign this look to the right position later, set
-`TINY_FILM_FILTER_RIGHT=wes_anderson` in the Pi's `.env` and restart the filter,
-shutter, and web services. Set capture contrast/saturation to 1, EV to 0, and
-warmup to 4 in `.env` to reproduce the baseline above. The gallery understands
-the new metadata labels; its three fixed mode badges still list the original
-switch defaults. The CLI is the tested selection path for this experiment.
+The existing **Cool** toggle now applies the same cream-and-cyan LUT as
+`wes_anderson`. Keep `TINY_FILM_FILTER_RIGHT=cool` in `.env`; the selection ID
+and mode badge remain `cool`. New Cool photos record **Cool · Wes pastels**,
+version 4, so their metadata distinguishes this grade from earlier Cool photos.
+`--photo-filter cool` and `--photo-filter wes_anderson` produce identical pixels.
+
+After deploying, restart the shutter and web services to load the new filter.
+No switch environment changes are needed. The same LUT also works when `cool`
+is selected through `TINY_FILM_CAPTURE_FILTER`. Capture contrast/saturation 1,
+EV 0, and warmup 4 reproduce the experimental baseline above; exposure and white
+balance still depend on scene lighting.
 
 ## Experiment: 5 September 2026
 

--- a/docs/wes-anderson-filter.md
+++ b/docs/wes-anderson-filter.md
@@ -1,0 +1,121 @@
+# Wes-inspired camera filter
+
+`wes_anderson` is a deterministic cream-and-cyan grade inspired by the warm
+pastels in Asteroid City. `wes_rose` is a softer pink/blue alternative. These
+are original RGB transforms, not official movie LUTs. No AI, synthesis,
+random grain, blur, object replacement, or queue is involved.
+
+The grade lifts midtones, gently compresses the tonal endpoints, moves blue
+fabric toward cyan and greens toward olive, and separates cream highlights
+from warm golden accents. A cached 33 × 33 × 33 Pillow LUT processes the pixels.
+The source should be a correctly exposed sRGB photograph, not sensor RAW.
+
+## Capture on the Pi
+
+Run from `/home/suveen/tiny-film`:
+
+```bash
+python3 src/tiny-film-cam/capture.py \
+  --photo-filter wes_anderson \
+  --contrast 1 --saturation 1 --sharpness 0.3 \
+  --ev 0 --warmup-seconds 4 --rotation 0 \
+  --keep-original
+```
+
+This writes a timestamped JPEG and filter-version sidecar under `data/captures`.
+`--keep-original` also saves the same rotated, ungraded frame as
+`<name>.original.png`, with a Normal sidecar. This is lossless ISP output,
+not Bayer RAW. Omit the option for faster saving and less storage use.
+
+The command uses the sensor's full 4608 × 2592 resolution. Add
+`--width 2304 --height 1296` for quicker experiments. Rotation 0 is correct for
+the camera's position during this experiment; the project's normal rotation
+remains 180. Exposure 0 worked for this room; it is not a universal exposure.
+Start there and lower exposure if important highlights clip.
+
+The explicit neutral contrast/saturation settings avoid stacking the existing
+camera's softened look underneath this filter. Warmup lets focus, exposure,
+and auto white balance settle; white balance is then locked for that capture.
+This does not lock gains across separate invocations or changing lighting.
+
+## Grade an existing photograph
+
+Run from the project root on either the Pi or a computer with Pillow:
+
+```bash
+python3 src/tiny-film-cam/grade.py original.png wes.jpg
+python3 src/tiny-film-cam/grade.py original.png softer.png --strength 0.7
+python3 src/tiny-film-cam/grade.py original.png rose.jpg --photo-filter wes_rose
+```
+
+Always choose a new output filename. The tool refuses to overwrite the input,
+existing output, or its metadata. It honors EXIF orientation, converts tagged
+ICC inputs to sRGB, and saves a JSON sidecar with source, strength, and filter
+version. JPEG quality is 95 with 4:4:4 sampling; PNG preserves exact graded
+pixels. Input EXIF is not copied into the output. An untagged input is assumed
+to be sRGB. Profile conversion requires Pillow's ImageCms support.
+
+Camera capture and this tool use `apply_photo_filter` from `photo_filters.py`.
+Given identical RGB inputs, filter name, and strength 1, their graded pixels
+are identical. JPEG files can differ if encoder settings differ.
+
+## Physical switch
+
+The CLI filter is installed on the Pi. Existing hardware switch mappings were
+left in place. To assign this look to the right position later, set
+`TINY_FILM_FILTER_RIGHT=wes_anderson` in the Pi's `.env` and restart the filter,
+shutter, and web services. Set capture contrast/saturation to 1, EV to 0, and
+warmup to 4 in `.env` to reproduce the baseline above. The gallery understands
+the new metadata labels; its three fixed mode badges still list the original
+switch defaults. The CLI is the tested selection path for this experiment.
+
+## Experiment: 5 September 2026
+
+Real IMX708 Camera Module 3 images are in `data/captures/wes-lab-20260905/`
+on the Pi and local workspace; they are intentionally ignored by Git.
+
+- Baseline: existing camera defaults, 2304 × 1296; upside down for this placement.
+- Exposure sweep: neutral ISP settings, rotation 0, 4-second warmup, EV 0,
+  +0.7, +1.0; fixed color gains and lens position across the sweep.
+  EV +0.7 put about 7% of channel samples at 254 or above. EV 0 retained
+  highlight detail, so the LUT supplies the brightness lift instead.
+- First iteration: subtle desert and rose grades. The user chose cream/cyan,
+  then correctly noted the subtle result did not look strongly Wes-inspired.
+- Second iteration: stronger cream/cyan separation and midtone lift; the main
+  `wes_anderson` v1 filter uses this direction.
+- Full resolution: `full-wes.jpg` plus its `.original.png`; later grading and
+  saving with the same JPEG settings produced a byte-identical JPEG.
+- Three repeated full-resolution LUT runs produced identical pixel SHA-256
+  hashes. After removing an unnecessary RGB copy, measured processing was
+  6.06 seconds first run, then 2.86 and 2.45 seconds. JPEG encoding took 0.93
+  seconds. Times vary with Pi load, swap, and LUT cache state; these exclude
+  loading, capture warmup, and optional PNG saving.
+- Full-resolution mean luma rose from 119.4 to 150.6 (0–255). The graded JPEG
+  contained no pixels with any channel at 255 in this scene. This is not a
+  guarantee against clipping for every input, particularly saturated colors.
+
+One repeated capture exposed a camera shutdown stall after the files had been
+saved. The capture path was changed to stop streaming immediately after the
+array is captured, before PNG saving and grading. A reboot released the stuck thread. After the change, three consecutive
+full-resolution captures completed: 40.63 seconds with a lossless original,
+then 12.02 and 11.97 seconds for JPEG-only output, all including 4-second
+warmup. This is a small repeat test, not a long-run soak test.
+
+Useful artifacts: `final-comparison.jpg`, `iteration-two.jpg`,
+`benchmark.json`, `image-metrics.json`, and exposure metadata JSON files.
+
+## What remains to tune
+
+This is a working color look, not a claim that an arbitrary room becomes a
+Wes Anderson film still. The available scene is mostly neutral and the camera
+is off-center. For a better visual test, place the camera level and directly
+opposite the bed, center the headboard, remove the foreground obstruction,
+and include a mustard/cream object with one cyan or red accent. Use broad,
+soft light. Then compare Normal and Wes from the same frame again.
+
+Only this indoor scene has been visually tuned. Before treating it as a
+universal preset, check daylight, skin tones, foliage, saturated reds, and
+low light. Evaluate white balance and exposure separately from the look;
+a static LUT cannot repair mixed lighting or recover clipped sensor detail.
+
+Reference: [Wes Anderson Color Palette Explained](https://spotlightfx.com/blog/wes-anderson-color-palette).

--- a/src/tiny-film-cam/README.md
+++ b/src/tiny-film-cam/README.md
@@ -106,3 +106,6 @@ The web app serves captures from `data/captures/` and exposes:
 - `GET /api/battery`
 - `GET /api/filter`
 - `GET /latest-image`
+
+For the Wes-inspired cream/cyan filter, real-photo comparisons, and capture or
+post-processing commands, see [Wes filter](../../docs/wes-anderson-filter.md).

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -101,6 +101,7 @@ class CaptureSettings:
     awb_mode: AwbMode = DEFAULT_AWB_MODE
     awb_lock: bool = DEFAULT_AWB_LOCK
     photo_filter: PhotoFilterName = DEFAULT_PHOTO_FILTER
+    keep_original: bool = False
 
 
 @dataclass(frozen=True)
@@ -418,7 +419,13 @@ def _capture_and_save_image(
     if on_captured is not None:
         on_captured()
     image = _image_from_picamera_frame(frame)
+    del frame  # Release the full sensor array before allocating graded pixels.
     image = _rotate_image(image, settings.rotation)
+    if settings.keep_original:
+        # Lossless, ungraded ISP output from this exact frame (not sensor RAW).
+        original_path = output_path.with_name(f"{output_path.stem}.original.png")
+        image.save(original_path, format="PNG")
+        write_photo_filter_metadata(original_path, "normal")
     image = apply_photo_filter(image, settings.photo_filter)
     image.save(
         output_path,
@@ -464,6 +471,16 @@ def capture_photos(
         exposure_values = _exposure_values(settings)
         started = False
 
+        def frame_captured() -> None:
+            nonlocal started
+            if on_captured is not None:
+                on_captured()
+            if len(exposure_values) == 1:
+                # capture_array owns its pixels. Stop streaming before slow
+                # PNG/LUT work on the memory-constrained Pi Zero.
+                picam2.stop()
+                started = False
+
         try:
             picam2.configure(config)
             picam2.start()
@@ -487,7 +504,7 @@ def capture_photos(
                     picam2,
                     settings,
                     output_path,
-                    on_captured,
+                    frame_captured,
                 )
         finally:
             if started:

--- a/src/tiny-film-cam/capture.py
+++ b/src/tiny-film-cam/capture.py
@@ -103,6 +103,11 @@ def parse_args() -> argparse.Namespace:
         help="Let AWB settle during warmup, then lock it before capture.",
     )
     parser.add_argument(
+        "--keep-original",
+        action="store_true",
+        help="Also save the same ungraded frame as a lossless .original.png for regrading.",
+    )
+    parser.add_argument(
         "--photo-filter",
         choices=PHOTO_FILTER_NAMES,
         default=DEFAULT_PHOTO_FILTER,
@@ -132,6 +137,7 @@ def main() -> None:
         awb_mode=args.awb_mode,
         awb_lock=args.awb_lock,
         photo_filter=args.photo_filter,
+        keep_original=args.keep_original,
     )
     output_paths = capture_photos(settings)
     for output_path in output_paths:

--- a/src/tiny-film-cam/grade.py
+++ b/src/tiny-film-cam/grade.py
@@ -1,0 +1,84 @@
+"""Grade existing photographs with the same LUT used during camera capture."""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import math
+from pathlib import Path
+
+from PIL import Image, ImageOps
+
+from photo_filters import PHOTO_FILTER_NAMES, apply_photo_filter, photo_filter_details
+
+
+def grade_file(source: Path, output: Path, photo_filter: str = "wes_anderson",
+               strength: float = 1.0) -> Path:
+    """Read an original once, normalize to sRGB, and write a new JPEG or PNG.
+
+    Existing outputs are never overwritten. Strength blends the original and
+    graded RGB pixels; always regrade from the original, not an earlier result.
+    """
+    if photo_filter not in PHOTO_FILTER_NAMES:
+        raise ValueError(f"Unknown photo filter: {photo_filter}")
+    if not math.isfinite(strength) or not 0.0 <= strength <= 1.0:
+        raise ValueError("Strength must be between 0 and 1")
+    if source.resolve() == output.resolve():
+        raise ValueError("Output must differ from the original")
+    image_format = {".jpg": "JPEG", ".jpeg": "JPEG", ".png": "PNG"}.get(output.suffix.lower())
+    if image_format is None:
+        raise ValueError("Output must be .jpg, .jpeg, or .png")
+    sidecar = output.with_name(output.name + ".json")
+    if output.exists() or sidecar.exists():
+        raise FileExistsError(f"Output already exists: {output}")
+    with Image.open(source) as opened:
+        original = ImageOps.exif_transpose(opened)
+        profile = original.info.get("icc_profile")
+        if profile:
+            from PIL import ImageCms
+
+            original = ImageCms.profileToProfile(
+                original, ImageCms.ImageCmsProfile(io.BytesIO(profile)),
+                ImageCms.createProfile("sRGB"), outputMode="RGB",
+            )
+        else:
+            original = original.convert("RGB")
+        graded = apply_photo_filter(original, photo_filter)
+        if strength != 1.0:
+            graded = Image.blend(original, graded, strength)
+        # The orientation is already baked into pixels; avoid stale thumbnails
+        # and color-profile tags from the input. Record provenance separately.
+        graded.info.clear()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("xb") as stream:
+            graded.save(stream, format=image_format, **(
+                {"quality": 95, "subsampling": 0} if image_format == "JPEG" else {}
+            ))
+    payload = {
+        "photo_filter": photo_filter_details(photo_filter),
+        "strength": strength,
+        "source": str(source.resolve()),
+        "color_space": "sRGB",
+        "processing": "deterministic color processing; no AI",
+    }
+    with sidecar.open("x", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2)
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--photo-filter", choices=PHOTO_FILTER_NAMES, default="wes_anderson")
+    parser.add_argument("--strength", type=float, default=1.0)
+    args = parser.parse_args()
+    try:
+        result = grade_file(args.source, args.output, args.photo_filter, args.strength)
+    except (ValueError, OSError) as exc:
+        parser.exit(1, f"Grading failed: {exc}\n")
+    print(f"Saved {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tiny-film-cam/photo_filters.py
+++ b/src/tiny-film-cam/photo_filters.py
@@ -32,8 +32,8 @@ PHOTO_FILTER_DETAILS: dict[PhotoFilterName, dict[str, object]] = {
     },
     "cool": {
         "id": "cool",
-        "label": "Cool",
-        "version": 3,
+        "label": "Cool · Wes pastels",
+        "version": 4,
     },
 }
 
@@ -71,56 +71,6 @@ def selected_photo_filter_from_cache(project_root: Path) -> PhotoFilterName:
     return normalize_photo_filter(active_filter.get("id"))
 
 
-def _scaled_lut(multiplier: float) -> list[int]:
-    return [max(0, min(255, round(value * multiplier))) for value in range(256)]
-
-
-def _smoothstep(edge0: float, edge1: float, value: float) -> float:
-    position = max(0.0, min(1.0, (value - edge0) / (edge1 - edge0)))
-    return position * position * (3.0 - 2.0 * position)
-
-
-_COOL_FILTER_LUT = None
-
-
-def _cool_filter_lut():
-    """Return a cached, Pi-friendly cyan/teal and warm-cream 3D color LUT."""
-    global _COOL_FILTER_LUT
-    if _COOL_FILTER_LUT is not None:
-        return _COOL_FILTER_LUT
-
-    from PIL import ImageFilter
-
-    def grade(red: float, green: float, blue: float):
-        luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
-
-        # Filmic contrast and restrained saturation form the pastel base.
-        red = (red - 0.48) * 1.14 + 0.48
-        green = (green - 0.48) * 1.14 + 0.48
-        blue = (blue - 0.48) * 1.14 + 0.48
-        red = luminance + (red - luminance) * 1.08
-        green = luminance + (green - luminance) * 1.08
-        blue = luminance + (blue - luminance) * 1.08
-
-        shadows = 1.0 - _smoothstep(0.16, 0.58, luminance)
-        midtones = _smoothstep(0.10, 0.45, luminance) * (
-            1.0 - _smoothstep(0.68, 0.96, luminance)
-        )
-        highlights = _smoothstep(0.46, 0.88, luminance)
-
-        # Keep orange, tan, and skin-like colors warm while neutral surfaces,
-        # greens, and blues receive the stronger Asteroid City-style cyan cast.
-        warm_color = _smoothstep(0.035, 0.18, red - blue)
-        cyan = midtones * (1.0 - 0.78 * warm_color)
-
-        red += -0.060 * shadows - 0.042 * cyan + 0.110 * highlights
-        green += 0.030 * shadows + 0.032 * cyan + 0.036 * highlights
-        blue += 0.072 * shadows + 0.070 * cyan - 0.045 * highlights
-        return red, green, blue
-
-    _COOL_FILTER_LUT = ImageFilter.Color3DLUT.generate(17, grade)
-    return _COOL_FILTER_LUT
-
 
 def apply_photo_filter(image, name: PhotoFilterName):
     """Apply a lightweight, versioned photo look to a Pillow image."""
@@ -136,9 +86,7 @@ def apply_photo_filter(image, name: PhotoFilterName):
         grayscale = ImageOps.grayscale(rgb_image)
         return ImageEnhance.Contrast(grayscale).enhance(1.08).convert("RGB")
 
-    if name in {"wes_anderson", "wes_rose"}:
-        from wes_palette import wes_lut
+    # Keep the existing switch/environment ID while using the Wes desert look.
+    from wes_palette import wes_lut
 
-        return rgb_image.filter(wes_lut("rose" if name == "wes_rose" else "desert"))
-
-    return rgb_image.filter(_cool_filter_lut())
+    return rgb_image.filter(wes_lut("rose" if name == "wes_rose" else "desert"))

--- a/src/tiny-film-cam/photo_filters.py
+++ b/src/tiny-film-cam/photo_filters.py
@@ -6,10 +6,20 @@ from typing import Literal, cast
 from filter_switch import filter_status_from_cache
 
 
-PhotoFilterName = Literal["black_and_white", "normal", "cool"]
+PhotoFilterName = Literal["black_and_white", "normal", "cool", "wes_anderson", "wes_rose"]
 DEFAULT_PHOTO_FILTER: PhotoFilterName = "normal"
-PHOTO_FILTER_NAMES = ("black_and_white", "normal", "cool")
+PHOTO_FILTER_NAMES = ("black_and_white", "normal", "cool", "wes_anderson", "wes_rose")
 PHOTO_FILTER_DETAILS: dict[PhotoFilterName, dict[str, object]] = {
+    "wes_anderson": {
+        "id": "wes_anderson",
+        "label": "Wes · Desert pastels",
+        "version": 1,
+    },
+    "wes_rose": {
+        "id": "wes_rose",
+        "label": "Wes · Rose pastels",
+        "version": 1,
+    },
     "black_and_white": {
         "id": "black_and_white",
         "label": "Black & white",
@@ -114,14 +124,21 @@ def _cool_filter_lut():
 
 def apply_photo_filter(image, name: PhotoFilterName):
     """Apply a lightweight, versioned photo look to a Pillow image."""
+    if name not in PHOTO_FILTER_NAMES:
+        raise ValueError(f"Unknown photo filter: {name}")
     if name == "normal":
         return image
 
     from PIL import ImageEnhance, ImageOps
 
-    rgb_image = image.convert("RGB")
+    rgb_image = image if image.mode == "RGB" else image.convert("RGB")
     if name == "black_and_white":
         grayscale = ImageOps.grayscale(rgb_image)
         return ImageEnhance.Contrast(grayscale).enhance(1.08).convert("RGB")
+
+    if name in {"wes_anderson", "wes_rose"}:
+        from wes_palette import wes_lut
+
+        return rgb_image.filter(wes_lut("rose" if name == "wes_rose" else "desert"))
 
     return rgb_image.filter(_cool_filter_lut())

--- a/src/tiny-film-cam/wes_palette.py
+++ b/src/tiny-film-cam/wes_palette.py
@@ -1,0 +1,70 @@
+"""Deterministic sRGB color grading; no generated pixels, grain, or scene analysis."""
+from __future__ import annotations
+
+import colorsys
+from functools import lru_cache
+
+
+def _smooth(a: float, b: float, value: float) -> float:
+    t = max(0.0, min(1.0, (value - a) / (b - a)))
+    return t * t * (3.0 - 2.0 * t)
+
+
+@lru_cache(maxsize=2)
+def wes_lut(palette: str = "desert"):
+    """Cache a small LUT; Pillow applies it in C with bounded per-pixel memory.
+
+    Input/output are display-referred sRGB, not linear sensor data. Smooth hue
+    masks keep gradients continuous. This is an inspired look, not a film LUT.
+    """
+    from PIL import ImageFilter
+
+    if palette not in {"desert", "rose"}:
+        raise ValueError(f"Unknown Wes palette: {palette}")
+
+    def grade(red: float, green: float, blue: float):
+        luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+        hue, saturation, value = colorsys.rgb_to_hsv(red, green, blue)
+
+        def hue_weight(center: float, width: float) -> float:
+            distance = abs((hue - center + 0.5) % 1.0 - 0.5)
+            return (1.0 - _smooth(0.0, width, distance)) * _smooth(
+                0.04, 0.25, saturation
+            )
+
+        blues = hue_weight(0.61, 0.18)
+        greens = hue_weight(0.34, 0.16)
+        reds = hue_weight(0.98, 0.10)
+        oranges = hue_weight(0.075, 0.12)
+        if palette == "desert":
+            # Dusty cyan blues, olive greens, restrained warm accents.
+            hue -= 0.070 * blues + 0.045 * greens
+            saturation *= 0.92 - 0.10 * greens
+            saturation = min(1.0, saturation + 0.12 * blues + 0.065 * oranges)
+        else:
+            hue += -0.018 * blues + 0.028 * greens - 0.022 * reds
+            saturation *= 0.80
+
+        rgb = colorsys.hsv_to_rgb(hue % 1.0, saturation, value)
+        adjusted_luma = sum(c * w for c, w in zip(rgb, (0.2126, 0.7152, 0.0722)))
+        # Lift midtones without an exposure multiplier that clips bright walls.
+        # Gentle endpoint compression retains detail in shadows and highlights.
+        if palette == "desert":
+            tone = 0.028 + 0.940 * luminance ** 0.72
+            rgb = tuple(tone + (c - adjusted_luma) * 1.02 for c in rgb)
+            mid = _smooth(0.015, 0.20, luminance) * (1.0 - _smooth(0.82, 1.0, luminance))
+            high = _smooth(0.40, 0.95, luminance)
+            warm = 1.0 - 0.85 * blues
+            tint = (0.066 * mid * warm + 0.024 * high,
+                    0.027 * mid + 0.009 * high,
+                    -0.049 * mid * warm - 0.045 * high)
+        else:
+            tone = 0.022 + 0.953 * luminance ** 0.86
+            rgb = tuple(tone + (c - adjusted_luma) * 0.98 for c in rgb)
+            mid = _smooth(0.03, 0.23, luminance) * (1.0 - _smooth(0.78, 1.0, luminance))
+            high = _smooth(0.35, 0.90, luminance)
+            tint = (0.030 * mid + 0.012 * high, -0.014 * mid,
+                    -0.002 * mid - 0.008 * high)
+        return tuple(max(0.0, min(1.0, c + t)) for c, t in zip(rgb, tint))
+
+    return ImageFilter.Color3DLUT.generate(33, grade)

--- a/tests/test_photo_filters.py
+++ b/tests/test_photo_filters.py
@@ -39,14 +39,14 @@ class PhotoFiltersTest(unittest.TestCase):
         self.assertEqual(red, green)
         self.assertEqual(green, blue)
 
-    def test_cool_filter_adds_teal_to_shadows(self) -> None:
+    def test_cool_filter_adds_warm_cream_to_neutrals(self) -> None:
         image = Image.new("RGB", (1, 1), (60, 60, 60))
 
         filtered = photo_filters.apply_photo_filter(image, "cool")
 
         red, green, blue = filtered.getpixel((0, 0))
-        self.assertLess(red, green)
-        self.assertGreater(blue, green)
+        self.assertGreater(red, green)
+        self.assertGreater(green, blue)
 
     def test_cool_filter_adds_gold_to_highlights(self) -> None:
         image = Image.new("RGB", (1, 1), (210, 210, 210))
@@ -58,7 +58,25 @@ class PhotoFiltersTest(unittest.TestCase):
         self.assertGreater(green, blue)
 
     def test_cool_filter_metadata_version_tracks_new_grade(self) -> None:
-        self.assertEqual(photo_filters.photo_filter_details("cool")["version"], 3)
+        self.assertEqual(photo_filters.photo_filter_details("cool")["version"], 4)
+
+    def test_cool_switch_uses_the_same_pixels_as_wes_anderson(self) -> None:
+        image = Image.new("RGB", (6, 1))
+        image.putdata([(0, 0, 0), (255, 255, 255), (60, 60, 60),
+                       (100, 140, 190), (150, 95, 45), (45, 170, 80)])
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            with patch.dict("os.environ", {"TINY_FILM_FILTER_RIGHT": "cool"}):
+                filter_switch.write_filter_cache(
+                    project_root / "data" / "filter-state.json",
+                    filter_switch.build_filter_state(left_grounded=False, right_grounded=True),
+                )
+            selected = photo_filters.selected_photo_filter_from_cache(project_root)
+        self.assertEqual(selected, "cool")
+        self.assertEqual(
+            photo_filters.apply_photo_filter(image, selected).tobytes(),
+            photo_filters.apply_photo_filter(image, "wes_anderson").tobytes(),
+        )
 
     def test_fresh_switch_selection_is_used(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_wes_grade.py
+++ b/tests/test_wes_grade.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+import json
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import MagicMock, patch
+import types
+
+import numpy as np
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src' / 'tiny-film-cam'))
+from photo_filters import apply_photo_filter
+from grade import grade_file
+from camera import CaptureSettings, _capture_and_save_image, capture_photos
+
+
+class WesGradeTest(unittest.TestCase):
+    def test_single_capture_stops_stream_before_grading(self):
+        events = []
+        device = MagicMock()
+        device.capture_array.side_effect = lambda *a: (
+            events.append('capture') or np.zeros((2, 2, 3), dtype=np.uint8)
+        )
+        device.stop.side_effect = lambda: events.append('stop')
+        device.close.side_effect = lambda: events.append('close')
+        fake_module = types.ModuleType('picamera2')
+        fake_module.Picamera2 = MagicMock(return_value=device)
+        fake_module.Picamera2.global_camera_info.return_value = [{}]
+        def grade(image, name):
+            events.append('grade')
+            return image
+        with TemporaryDirectory() as tmp, patch.dict(sys.modules, {'picamera2': fake_module}), patch('camera.apply_photo_filter', side_effect=grade):
+            capture_photos(CaptureSettings(output_dir=Path(tmp), warmup_seconds=0),
+                           on_captured=lambda: events.append('notify'))
+        self.assertEqual(events, ['capture', 'notify', 'stop', 'grade', 'close'])
+
+    def test_repeatable_smooth_neutral_ramp(self):
+        ramp = Image.fromarray(np.tile(np.arange(256, dtype=np.uint8)[None, :, None], (2, 1, 3)))
+        first = apply_photo_filter(ramp, 'wes_anderson')
+        self.assertEqual(first.tobytes(), apply_photo_filter(ramp, 'wes_anderson').tobytes())
+        result = np.asarray(first).astype(int)
+        self.assertTrue((np.diff(result, axis=1) >= 0).all())
+        self.assertLessEqual(np.diff(result, axis=1).max(), 3)
+        r, g, b = first.getpixel((128, 0))
+        self.assertGreater(r, g)
+        self.assertGreater(g, b)
+        self.assertGreater(min(first.getpixel((0, 0))), 0)
+        self.assertLess(max(first.getpixel((255, 0))), 255)
+
+    def test_blues_become_cyan_and_wood_stays_warm(self):
+        import colorsys
+        image = Image.new('RGB', (2, 1))
+        image.putdata([(100, 140, 190), (150, 95, 45)])
+        result = apply_photo_filter(image, 'wes_anderson')
+        blue_hue = colorsys.rgb_to_hsv(*(c / 255 for c in result.getpixel((0, 0))))[0]
+        self.assertTrue(0.45 < blue_hue < 0.57)
+        r, g, b = result.getpixel((1, 0))
+        self.assertGreater(r, g)
+        self.assertGreater(g, b)
+
+    def test_saved_original_regrades_to_same_capture_pixels(self):
+        with TemporaryDirectory() as tmp:
+            out = Path(tmp) / 'shot.jpg'
+            camera = MagicMock()
+            camera.capture_array.return_value = np.array([[[30, 70, 140], [180, 130, 90]]], dtype=np.uint8)
+            _capture_and_save_image(camera, CaptureSettings(photo_filter='wes_anderson', keep_original=True, rotation=0), out, None)
+            original = out.with_name('shot.original.png')
+            regraded = Path(tmp) / 'regraded.png'
+            grade_file(original, regraded)
+            with Image.open(original) as raw, Image.open(regraded) as actual:
+                self.assertEqual(raw.getpixel((0, 0)), (140, 70, 30))
+                self.assertEqual(actual.tobytes(), apply_photo_filter(raw, 'wes_anderson').tobytes())
+            metadata = json.loads(out.with_name('shot.jpg.json').read_text())
+            self.assertEqual(metadata['photo_filter']['id'], 'wes_anderson')
+
+    def test_strength_zero_orientation_and_no_overwrite(self):
+        with TemporaryDirectory() as tmp:
+            original = Path(tmp) / 'in.png'
+            result = Path(tmp) / 'out.png'
+            img = Image.new('RGB', (2, 3), (30, 80, 120))
+            exif = Image.Exif()
+            exif[274] = 6
+            img.save(original, exif=exif)
+            before = original.read_bytes()
+            grade_file(original, result, strength=0)
+            with Image.open(result) as graded:
+                self.assertEqual(graded.size, (3, 2))
+                self.assertEqual(graded.getpixel((0, 0)), (30, 80, 120))
+                self.assertNotIn(274, graded.getexif())
+            self.assertEqual(original.read_bytes(), before)
+            with self.assertRaises(FileExistsError):
+                grade_file(original, result)
+            with self.assertRaises(ValueError):
+                grade_file(original, original)
+            for strength in [-.1, 1.1, float('nan')]:
+                with self.assertRaises(ValueError):
+                    grade_file(original, Path(tmp) / 'invalid.png', strength=strength)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The existing **Cool** toggle now applies the Wes-inspired cream-and-cyan grade. Keep `TINY_FILM_FILTER_RIGHT=cool`: no environment or switch configuration change is needed. `cool` and `wes_anderson` use the same deterministic Pillow RGB LUT. New Cool photos record version 4 with the label “Cool · Wes pastels.”

The same grading is available during capture and for existing photographs:
- `capture.py --photo-filter cool --keep-original` saves a graded JPEG and the same ungraded frame as a lossless PNG.
- `grade.py original.png output.jpg --photo-filter cool` applies the same look later, with optional strength adjustment, EXIF orientation handling, sRGB conversion, and versioned metadata. Existing files are not overwritten.
- `wes_rose` provides a softer pink/blue alternative. No AI or random effects are used.

Single-frame capture stops streaming before processing and releases unnecessary image buffers, addressing a shutdown stall observed during full-resolution testing on the Pi. Documentation covers capture settings, exposure comparisons, timing, and visual limitations. Restart the shutter and web services after deploying so they load the new code.

Validation:
- `python3 -m unittest discover -s tests -q`: **91 tests pass** on this branch based on current main, including a test that `TINY_FILM_FILTER_RIGHT=cool` resolves through the switch cache and produces identical pixels to `wes_anderson`.
- The Wes LUT and capture lifecycle were tested with three consecutive 4608 × 2592 captures on the Pi: approximately 41 seconds with an original PNG and 12 seconds each for JPEG-only output, including a 4-second warmup.
- Direct capture and later grading of its original produced identical JPEGs with matching encoder settings.

The look was tuned on real indoor photos. Daylight, skin tones, and long-running capture reliability still need broader testing; this is an inspired palette, not an official film LUT. The latest Cool mapping has been tested locally; deployment to the Pi will follow merge.
