### PR TITLE
Move camera controls into per-filter profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,9 +63,8 @@ TINY_FILM_CAPTURE_WIDTH=
 TINY_FILM_CAPTURE_HEIGHT=
 TINY_FILM_CAPTURE_QUALITY=95
 TINY_FILM_CAPTURE_SHARPNESS=0.3
-TINY_FILM_CAPTURE_CONTRAST=0.85
-TINY_FILM_CAPTURE_SATURATION=0.9
-TINY_FILM_CAPTURE_EV=-0.3
+# Contrast, saturation, EV, and exposure/AWB warmup belong to the selected
+# photo filter's capture profile in photo_filters.py.
 # Optional comma-separated EV bracket values. Example: 0,-0.7,-1.0
 TINY_FILM_CAPTURE_BRACKETS=
 TINY_FILM_CAPTURE_BRACKET_SETTLE_SECONDS=0.25
@@ -79,7 +78,6 @@ TINY_FILM_CAPTURE_AWB_LOCK=1
 TINY_FILM_CAPTURE_FILTER=normal
 # Clockwise rotation applied to the saved JPEG pixels: 0, 90, 180, or 270.
 TINY_FILM_CAPTURE_ROTATION=0
-TINY_FILM_CAPTURE_WARMUP_SECONDS=0.5
 TINY_FILM_CAPTURE_FOCUS_MODE=continuous
 # Lens position is used only when focus mode is manual. Leave blank otherwise.
 TINY_FILM_CAPTURE_LENS_POSITION=

--- a/docs/wes-anderson-filter.md
+++ b/docs/wes-anderson-filter.md
@@ -17,8 +17,7 @@ Run from `/home/suveen/tiny-film`:
 ```bash
 python3 src/tiny-film-cam/capture.py \
   --photo-filter wes_anderson \
-  --contrast 1 --saturation 1 --sharpness 0.3 \
-  --ev 0 --warmup-seconds 4 --rotation 0 \
+  --sharpness 0.3 --rotation 0 \
   --keep-original
 ```
 
@@ -33,10 +32,12 @@ the camera's position during this experiment; the project's normal rotation
 remains 180. Exposure 0 worked for this room; it is not a universal exposure.
 Start there and lower exposure if important highlights clip.
 
-The explicit neutral contrast/saturation settings avoid stacking the existing
-camera's softened look underneath this filter. Warmup lets focus, exposure,
-and auto white balance settle; white balance is then locked for that capture.
-This does not lock gains across separate invocations or changing lighting.
+The selected filter supplies contrast, saturation, EV, and warmup from its
+capture profile in `photo_filters.py`. Cool and both Wes aliases use contrast
+1, saturation 1, EV 0, and a 4-second warmup. Warmup lets focus, exposure, and
+auto white balance settle; white balance is then locked for that capture. This
+does not lock gains across separate invocations or changing lighting. CLI
+options can temporarily override a profile for a controlled experiment.
 
 ## Grade an existing photograph
 
@@ -69,9 +70,9 @@ version 4, so their metadata distinguishes this grade from earlier Cool photos.
 
 After deploying, restart the shutter and web services to load the new filter.
 No switch environment changes are needed. The same LUT also works when `cool`
-is selected through `TINY_FILM_CAPTURE_FILTER`. Capture contrast/saturation 1,
-EV 0, and warmup 4 reproduce the experimental baseline above; exposure and white
-balance still depend on scene lighting.
+is selected through `TINY_FILM_CAPTURE_FILTER`. The four profile controls are
+no longer read from `.env`; exposure and white balance still depend on scene
+lighting.
 
 ## Experiment: 5 September 2026
 
@@ -89,6 +90,10 @@ on the Pi and local workspace; they are intentionally ignored by Git.
   `wes_anderson` v1 filter uses this direction.
 - Full resolution: `full-wes.jpg` plus its `.original.png`; later grading and
   saving with the same JPEG settings produced a byte-identical JPEG.
+- A same-room comparison after dark used identical Cool settings except for
+  warmup. At 0.5 seconds, mean RGB was 171/148/108 and the image was visibly
+  yellow; at 4 seconds it was 156/148/124 with cleaner cream and cyan
+  separation. Cool therefore keeps the 4-second warmup in its filter profile.
 - Three repeated full-resolution LUT runs produced identical pixel SHA-256
   hashes. After removing an unnecessary RGB copy, measured processing was
   6.06 seconds first run, then 2.86 and 2.45 seconds. JPEG encoding took 0.93

--- a/src/tiny-film-cam/camera.py
+++ b/src/tiny-film-cam/camera.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 import fcntl
 import os
@@ -15,6 +15,7 @@ from photo_filters import (
     PhotoFilterName,
     apply_photo_filter,
     normalize_photo_filter,
+    photo_filter_capture_profile,
 )
 
 
@@ -89,13 +90,13 @@ class CaptureSettings:
     height: int | None = None
     quality: int = DEFAULT_QUALITY
     sharpness: float = DEFAULT_SHARPNESS
-    contrast: float = DEFAULT_CONTRAST
-    saturation: float = DEFAULT_SATURATION
-    exposure_value: float = DEFAULT_EXPOSURE_VALUE
+    contrast: float | None = None
+    saturation: float | None = None
+    exposure_value: float | None = None
     exposure_brackets: tuple[float, ...] = ()
     bracket_settle_seconds: float = DEFAULT_BRACKET_SETTLE_SECONDS
     rotation: Rotation = DEFAULT_ROTATION
-    warmup_seconds: float = DEFAULT_WARMUP_SECONDS
+    warmup_seconds: float | None = None
     focus_mode: FocusMode = DEFAULT_FOCUS_MODE
     lens_position: float | None = None
     awb_mode: AwbMode = DEFAULT_AWB_MODE
@@ -195,18 +196,12 @@ def capture_settings_from_env(project_root: Path) -> CaptureSettings:
         height=env_optional_int("TINY_FILM_CAPTURE_HEIGHT"),
         quality=env_int("TINY_FILM_CAPTURE_QUALITY", DEFAULT_QUALITY),
         sharpness=env_float("TINY_FILM_CAPTURE_SHARPNESS", DEFAULT_SHARPNESS),
-        contrast=env_float("TINY_FILM_CAPTURE_CONTRAST", DEFAULT_CONTRAST),
-        saturation=env_float("TINY_FILM_CAPTURE_SATURATION", DEFAULT_SATURATION),
-        exposure_value=env_float("TINY_FILM_CAPTURE_EV", DEFAULT_EXPOSURE_VALUE),
         exposure_brackets=env_float_tuple("TINY_FILM_CAPTURE_BRACKETS"),
         bracket_settle_seconds=env_float(
             "TINY_FILM_CAPTURE_BRACKET_SETTLE_SECONDS",
             DEFAULT_BRACKET_SETTLE_SECONDS,
         ),
         rotation=rotation,  # type: ignore[arg-type]
-        warmup_seconds=env_float(
-            "TINY_FILM_CAPTURE_WARMUP_SECONDS", DEFAULT_WARMUP_SECONDS
-        ),
         focus_mode=focus_mode,  # type: ignore[arg-type]
         lens_position=env_optional_float("TINY_FILM_CAPTURE_LENS_POSITION"),
         awb_mode=awb_mode,  # type: ignore[arg-type]
@@ -235,17 +230,42 @@ def video_settings_from_env(project_root: Path) -> VideoSettings:
         duration_seconds=DEFAULT_VIDEO_DURATION_SECONDS,
         bitrate=None,
         sharpness=env_float("TINY_FILM_CAPTURE_SHARPNESS", DEFAULT_SHARPNESS),
-        contrast=env_float("TINY_FILM_CAPTURE_CONTRAST", DEFAULT_CONTRAST),
-        saturation=env_float("TINY_FILM_CAPTURE_SATURATION", DEFAULT_SATURATION),
-        exposure_value=env_float("TINY_FILM_CAPTURE_EV", DEFAULT_EXPOSURE_VALUE),
+        contrast=DEFAULT_CONTRAST,
+        saturation=DEFAULT_SATURATION,
+        exposure_value=DEFAULT_EXPOSURE_VALUE,
         rotation=rotation,  # type: ignore[arg-type]
-        warmup_seconds=env_float(
-            "TINY_FILM_CAPTURE_WARMUP_SECONDS", DEFAULT_WARMUP_SECONDS
-        ),
+        warmup_seconds=DEFAULT_WARMUP_SECONDS,
         focus_mode=focus_mode,  # type: ignore[arg-type]
         lens_position=env_optional_float("TINY_FILM_CAPTURE_LENS_POSITION"),
         awb_mode=awb_mode,  # type: ignore[arg-type]
         awb_lock=env_bool("TINY_FILM_CAPTURE_AWB_LOCK", DEFAULT_AWB_LOCK),
+    )
+
+
+def resolve_photo_capture_settings(settings: CaptureSettings) -> CaptureSettings:
+    """Fill unset sensor controls from the selected filter's capture profile.
+
+    Explicit Python or CLI values remain useful for controlled experiments,
+    while normal web, shutter, and environment-driven captures consistently
+    use the profile selected by the physical filter switch.
+    """
+    profile = photo_filter_capture_profile(settings.photo_filter)
+    return replace(
+        settings,
+        contrast=profile.contrast if settings.contrast is None else settings.contrast,
+        saturation=(
+            profile.saturation if settings.saturation is None else settings.saturation
+        ),
+        exposure_value=(
+            profile.exposure_value
+            if settings.exposure_value is None
+            else settings.exposure_value
+        ),
+        warmup_seconds=(
+            profile.warmup_seconds
+            if settings.warmup_seconds is None
+            else settings.warmup_seconds
+        ),
     )
 
 
@@ -333,6 +353,8 @@ def _image_from_picamera_frame(frame):
 
 
 def _camera_controls(settings: "CaptureSettings | VideoSettings") -> dict[str, object]:
+    if isinstance(settings, CaptureSettings):
+        settings = resolve_photo_capture_settings(settings)
     controls: dict[str, object] = {
         "Sharpness": settings.sharpness,
         "Contrast": settings.contrast,
@@ -441,6 +463,8 @@ def capture_photos(
 ) -> list[Path]:
     """Capture still images, notifying after each frame and before JPEG saving."""
     import time
+
+    settings = resolve_photo_capture_settings(settings)
 
     try:
         __import__("PIL.Image")

--- a/src/tiny-film-cam/capture.py
+++ b/src/tiny-film-cam/capture.py
@@ -9,14 +9,10 @@ from camera import (
     DEFAULT_AWB_LOCK,
     DEFAULT_AWB_MODE,
     DEFAULT_BRACKET_SETTLE_SECONDS,
-    DEFAULT_CONTRAST,
-    DEFAULT_EXPOSURE_VALUE,
     DEFAULT_FOCUS_MODE,
     DEFAULT_QUALITY,
     DEFAULT_ROTATION,
-    DEFAULT_SATURATION,
     DEFAULT_SHARPNESS,
-    DEFAULT_WARMUP_SECONDS,
     capture_photos,
 )
 from photo_filters import DEFAULT_PHOTO_FILTER, PHOTO_FILTER_NAMES
@@ -46,13 +42,20 @@ def parse_args() -> argparse.Namespace:
         "--quality", type=int, default=DEFAULT_QUALITY, help="JPEG quality, 1-100."
     )
     parser.add_argument("--sharpness", type=float, default=DEFAULT_SHARPNESS)
-    parser.add_argument("--contrast", type=float, default=DEFAULT_CONTRAST)
-    parser.add_argument("--saturation", type=float, default=DEFAULT_SATURATION)
+    parser.add_argument(
+        "--contrast",
+        type=float,
+        help="Override the selected photo filter's contrast.",
+    )
+    parser.add_argument(
+        "--saturation",
+        type=float,
+        help="Override the selected photo filter's saturation.",
+    )
     parser.add_argument(
         "--ev",
         type=float,
-        default=DEFAULT_EXPOSURE_VALUE,
-        help="Exposure compensation in stops, e.g. -0.7 to protect highlights.",
+        help="Override the selected photo filter's exposure compensation.",
     )
     parser.add_argument(
         "--exposure-brackets",
@@ -76,8 +79,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--warmup-seconds",
         type=float,
-        default=DEFAULT_WARMUP_SECONDS,
-        help="Seconds to let exposure/focus settle before capture.",
+        help="Override the selected photo filter's exposure/AWB warmup.",
     )
     parser.add_argument(
         "--focus-mode",

--- a/src/tiny-film-cam/photo_filters.py
+++ b/src/tiny-film-cam/photo_filters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
 
@@ -9,6 +10,37 @@ from filter_switch import filter_status_from_cache
 PhotoFilterName = Literal["black_and_white", "normal", "cool", "wes_anderson", "wes_rose"]
 DEFAULT_PHOTO_FILTER: PhotoFilterName = "normal"
 PHOTO_FILTER_NAMES = ("black_and_white", "normal", "cool", "wes_anderson", "wes_rose")
+
+
+@dataclass(frozen=True)
+class PhotoCaptureProfile:
+    """Camera controls that prepare a sensor frame for one photo filter."""
+
+    contrast: float
+    saturation: float
+    exposure_value: float
+    warmup_seconds: float
+
+
+_STANDARD_CAPTURE_PROFILE = PhotoCaptureProfile(
+    contrast=0.85,
+    saturation=0.9,
+    exposure_value=-0.3,
+    warmup_seconds=0.5,
+)
+_WES_CAPTURE_PROFILE = PhotoCaptureProfile(
+    contrast=1.0,
+    saturation=1.0,
+    exposure_value=0.0,
+    warmup_seconds=4.0,
+)
+PHOTO_FILTER_CAPTURE_PROFILES: dict[PhotoFilterName, PhotoCaptureProfile] = {
+    "black_and_white": _STANDARD_CAPTURE_PROFILE,
+    "normal": _STANDARD_CAPTURE_PROFILE,
+    "cool": _WES_CAPTURE_PROFILE,
+    "wes_anderson": _WES_CAPTURE_PROFILE,
+    "wes_rose": _WES_CAPTURE_PROFILE,
+}
 PHOTO_FILTER_DETAILS: dict[PhotoFilterName, dict[str, object]] = {
     "wes_anderson": {
         "id": "wes_anderson",
@@ -46,6 +78,10 @@ def normalize_photo_filter(value: object) -> PhotoFilterName:
 
 def photo_filter_details(name: PhotoFilterName) -> dict[str, object]:
     return dict(PHOTO_FILTER_DETAILS[name])
+
+
+def photo_filter_capture_profile(name: PhotoFilterName) -> PhotoCaptureProfile:
+    return PHOTO_FILTER_CAPTURE_PROFILES[name]
 
 
 def photo_filter_status_from_cache(project_root: Path) -> dict[str, object]:

--- a/src/tiny-film-cam/shutter_daemon.py
+++ b/src/tiny-film-cam/shutter_daemon.py
@@ -429,17 +429,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--contrast",
         type=float,
-        default=capture_defaults.contrast,
+        help="Override the selected photo filter's contrast.",
     )
     parser.add_argument(
         "--saturation",
         type=float,
-        default=capture_defaults.saturation,
+        help="Override the selected photo filter's saturation.",
     )
     parser.add_argument(
         "--ev",
         type=float,
-        default=capture_defaults.exposure_value,
+        help="Override the selected photo filter's exposure compensation.",
     )
     parser.add_argument(
         "--exposure-brackets",
@@ -461,7 +461,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--warmup-seconds",
         type=float,
-        default=capture_defaults.warmup_seconds,
+        help="Override the selected photo filter's exposure/AWB warmup.",
     )
     parser.add_argument(
         "--focus-mode",
@@ -487,6 +487,12 @@ def parse_args() -> argparse.Namespace:
         "--no-awb-lock",
         dest="awb_lock",
         action="store_false",
+    )
+    parser.set_defaults(
+        video_contrast=video_defaults.contrast,
+        video_saturation=video_defaults.saturation,
+        video_exposure_value=video_defaults.exposure_value,
+        video_warmup_seconds=video_defaults.warmup_seconds,
     )
     return parser.parse_args()
 
@@ -568,11 +574,23 @@ def main() -> None:
                 fps=args.video_fps,
                 duration_seconds=args.video_duration,
                 sharpness=args.sharpness,
-                contrast=args.contrast,
-                saturation=args.saturation,
-                exposure_value=args.ev,
+                contrast=(
+                    args.video_contrast if args.contrast is None else args.contrast
+                ),
+                saturation=(
+                    args.video_saturation
+                    if args.saturation is None
+                    else args.saturation
+                ),
+                exposure_value=(
+                    args.video_exposure_value if args.ev is None else args.ev
+                ),
                 rotation=args.rotation,
-                warmup_seconds=args.warmup_seconds,
+                warmup_seconds=(
+                    args.video_warmup_seconds
+                    if args.warmup_seconds is None
+                    else args.warmup_seconds
+                ),
                 focus_mode=args.focus_mode,
                 lens_position=args.lens_position,
                 awb_mode=args.awb_mode,

--- a/tests/test_camera_rotation.py
+++ b/tests/test_camera_rotation.py
@@ -188,18 +188,24 @@ class CameraRotationTest(unittest.TestCase):
             settings = camera.capture_settings_from_env(Path.cwd())
 
         self.assertEqual(settings.sharpness, 0.3)
-        self.assertEqual(settings.contrast, 0.85)
-        self.assertEqual(settings.saturation, 0.9)
-        self.assertEqual(settings.exposure_value, -0.3)
+        self.assertIsNone(settings.contrast)
+        self.assertIsNone(settings.saturation)
+        self.assertIsNone(settings.exposure_value)
+        self.assertIsNone(settings.warmup_seconds)
         self.assertEqual(settings.awb_mode, "auto")
         self.assertTrue(settings.awb_lock)
         self.assertEqual(settings.photo_filter, "normal")
 
-    def test_capture_settings_reads_film_source_controls_from_env(self) -> None:
+    def test_capture_settings_ignore_legacy_env_controls_and_use_filter_profile(
+        self,
+    ) -> None:
         with patch.dict(
             "os.environ",
             {
                 "TINY_FILM_CAPTURE_EV": "-0.7",
+                "TINY_FILM_CAPTURE_CONTRAST": "0.1",
+                "TINY_FILM_CAPTURE_SATURATION": "0.2",
+                "TINY_FILM_CAPTURE_WARMUP_SECONDS": "0.1",
                 "TINY_FILM_CAPTURE_BRACKETS": "0,-0.7,-1.0",
                 "TINY_FILM_CAPTURE_BRACKET_SETTLE_SECONDS": "0.4",
                 "TINY_FILM_CAPTURE_AWB_MODE": "cloudy",
@@ -210,12 +216,32 @@ class CameraRotationTest(unittest.TestCase):
         ):
             settings = camera.capture_settings_from_env(Path.cwd())
 
-        self.assertEqual(settings.exposure_value, -0.7)
+        resolved = camera.resolve_photo_capture_settings(settings)
+        self.assertEqual(resolved.contrast, 1.0)
+        self.assertEqual(resolved.saturation, 1.0)
+        self.assertEqual(resolved.exposure_value, 0.0)
+        self.assertEqual(resolved.warmup_seconds, 4.0)
         self.assertEqual(settings.exposure_brackets, (0.0, -0.7, -1.0))
         self.assertEqual(settings.bracket_settle_seconds, 0.4)
         self.assertEqual(settings.awb_mode, "cloudy")
         self.assertTrue(settings.awb_lock)
         self.assertEqual(settings.photo_filter, "cool")
+
+    def test_explicit_capture_controls_override_filter_profile(self) -> None:
+        settings = camera.CaptureSettings(
+            photo_filter="cool",
+            contrast=0.7,
+            saturation=0.8,
+            exposure_value=-1.0,
+            warmup_seconds=0.25,
+        )
+
+        resolved = camera.resolve_photo_capture_settings(settings)
+
+        self.assertEqual(resolved.contrast, 0.7)
+        self.assertEqual(resolved.saturation, 0.8)
+        self.assertEqual(resolved.exposure_value, -1.0)
+        self.assertEqual(resolved.warmup_seconds, 0.25)
 
     def test_bracket_output_paths_include_ev_suffixes(self) -> None:
         settings = camera.CaptureSettings(

--- a/tests/test_photo_filters.py
+++ b/tests/test_photo_filters.py
@@ -23,6 +23,27 @@ web = importlib.import_module("web")
 
 
 class PhotoFiltersTest(unittest.TestCase):
+    def test_capture_profiles_are_owned_by_each_filter(self) -> None:
+        normal = photo_filters.photo_filter_capture_profile("normal")
+        black_and_white = photo_filters.photo_filter_capture_profile(
+            "black_and_white"
+        )
+        cool = photo_filters.photo_filter_capture_profile("cool")
+        wes = photo_filters.photo_filter_capture_profile("wes_anderson")
+
+        self.assertEqual(
+            (normal.contrast, normal.saturation, normal.exposure_value,
+             normal.warmup_seconds),
+            (0.85, 0.9, -0.3, 0.5),
+        )
+        self.assertEqual(black_and_white, normal)
+        self.assertEqual(
+            (cool.contrast, cool.saturation, cool.exposure_value,
+             cool.warmup_seconds),
+            (1.0, 1.0, 0.0, 4.0),
+        )
+        self.assertEqual(wes, cool)
+
     def test_normal_filter_keeps_pixels_unchanged(self) -> None:
         image = Image.new("RGB", (1, 1), (80, 100, 120))
 


### PR DESCRIPTION
The photo filter now owns contrast, saturation, exposure compensation, and exposure/AWB warmup. Web captures, the shutter button, direct environment-driven captures, and camera controls all resolve these values after the active filter is known, so a global `.env` value can no longer make Cool use Normal's sensor setup.

- Cool, Wes Desert, and Wes Rose use contrast 1, saturation 1, EV 0, and a 4-second warmup.
- Normal and Black & white retain contrast 0.85, saturation 0.9, EV -0.3, and a 0.5-second warmup.
- The four old `.env` entries are removed and ignored. Explicit CLI values remain available for controlled experiments.
- Video retains its established camera defaults.

Validation:

- `python3 -m unittest discover -s tests -q`: 93 tests pass.
- Added coverage for every filter profile, ignored legacy environment values, profile resolution, and explicit CLI overrides.
- On the real Pi in the same room and lighting, a Cool capture with 0.5-second warmup was visibly yellow (mean RGB 171/148/108); the 4-second capture was cleaner (156/148/124). Cool therefore uses 4 seconds.
